### PR TITLE
feat: add setup-mq composite action for CI consumption

### DIFF
--- a/.github/actions/setup-mq/action.yml
+++ b/.github/actions/setup-mq/action.yml
@@ -1,0 +1,37 @@
+name: Setup MQ Dev Environment
+description: >-
+  Start IBM MQ containers (QM1 + QM2), seed shared test objects,
+  and verify the environment is ready.
+
+inputs:
+  verify:
+    description: Run mq_verify.sh after seeding
+    required: false
+    default: 'true'
+
+outputs:
+  qm1-rest-url:
+    description: QM1 REST API base URL
+    value: https://localhost:9443/ibmmq/rest/v2
+  qm2-rest-url:
+    description: QM2 REST API base URL
+    value: https://localhost:9444/ibmmq/rest/v2
+
+runs:
+  using: composite
+  steps:
+    - name: Start MQ containers
+      shell: bash
+      working-directory: ${{ github.action_path }}/../../..
+      run: scripts/mq_start.sh
+
+    - name: Seed MQ objects
+      shell: bash
+      working-directory: ${{ github.action_path }}/../../..
+      run: scripts/mq_seed.sh
+
+    - name: Verify MQ environment
+      if: inputs.verify == 'true'
+      shell: bash
+      working-directory: ${{ github.action_path }}/../../..
+      run: scripts/mq_verify.sh

--- a/docs/plans/open-decisions.md
+++ b/docs/plans/open-decisions.md
@@ -42,12 +42,13 @@ Track decisions for the shared MQ test environment repository.
 
 - **Local development**: Sibling directory `../mq-dev-environment` (decided
   2026-02-13, see `docs/plans/2026-02-13-repository-design.md`).
-- **CI**: TBD -- reusable workflow vs. composite action (composite action
-  likely preferred).
+- **CI**: Composite action in this repo at
+  `.github/actions/setup-mq/action.yml` (decided 2026-02-13).
 
 ## CI integration
 
-- **Workflow type**: TBD (reusable workflow vs. composite action).
+- **Workflow type**: Composite action at
+  `.github/actions/setup-mq/action.yml` (decided 2026-02-13).
 - **Container image caching**: TBD.
 - **pymqrest migration**: TBD (update pymqrest to consume from this repo).
 - **mq-rest-admin integration**: TBD (add integration test support).


### PR DESCRIPTION
## Summary

- Add `.github/actions/setup-mq/action.yml` composite action that
  starts QM1+QM2 containers, seeds shared test objects, and optionally
  verifies the environment — giving consuming repos a single `uses:`
  step for CI integration testing
- Update `docs/plans/open-decisions.md` to mark CI workflow type as
  decided (composite action)

## Test plan

- [ ] Validate action.yml YAML syntax (`python3 -c "import yaml; ..."`)
- [ ] Run markdownlint with zero errors
- [ ] End-to-end: consume the action from a pymqrest workflow branch
  to confirm containers start, seed, and verify successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)