### PR TITLE
feat: add weekly Trivy container image scan

### DIFF
--- a/.github/workflows/trivy-image.yml
+++ b/.github/workflows/trivy-image.yml
@@ -1,0 +1,24 @@
+name: Trivy Container Image Scan
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  security-events: write
+
+jobs:
+  trivy-image:
+    name: trivy-image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Scan MQ container image
+        uses: wphillipmoore/standard-actions/actions/security/trivy@develop
+        with:
+          scan-type: image
+          scan-ref: icr.io/ibm-messaging/mq:latest
+          exit-code: "0"


### PR DESCRIPTION
## Summary

- Add weekly Trivy container image scan workflow for `icr.io/ibm-messaging/mq:latest`
- Advisory-only (exit-code 0) since this is a vendor image
- Runs Monday 6am UTC on schedule, also supports manual dispatch
- Uploads SARIF results to GitHub Security tab

## Test plan

- [ ] Workflow YAML validates
- [ ] Manual workflow dispatch succeeds after merge
- [ ] SARIF results appear in GitHub Security tab

Fixes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)