### PR TITLE
ci: auto-add issues to GitHub Project

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,14 @@
+name: Add to project
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1
+        with:
+          project-url: https://github.com/users/wphillipmoore/projects/3
+          github-token: ${{ secrets.PROJECT_TOKEN }}


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow to automatically add new issues to the mq-rest-admin GitHub Project
- Uses the official actions/add-to-project@v1 action
- Triggers on issues: opened events
- Requires PROJECT_TOKEN repository secret (already configured)

Closes #15

## Issue Linkage

- Fixes #15

## Testing

- Workflow syntax validated by inspection (identical to deployed workflow in all other mq-rest-admin repos)

## Notes

- Last mq-rest-admin repo to receive this workflow
