### PR TITLE
docs: update self-references after repository rename

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ repositories. Provides container lifecycle scripts, seed data, and
 a reusable GitHub Actions workflow for integration testing against
 a real MQ queue manager.
 
-**Project name**: mq-dev-environment
+**Project name**: mq-rest-admin-dev-environment
 
 **Status**: Pre-alpha (initial setup)
 
@@ -115,7 +115,7 @@ Consuming repositories depend on these stable details:
 ### Consumption Model
 
 - **Local development**: Consuming repos reference this repo as a
-  sibling directory (`../mq-dev-environment`) — same pattern as
+  sibling directory (`../mq-rest-admin-dev-environment`) — same pattern as
   `../standards-and-conventions`
 - **CI**: Reusable GitHub Actions workflow (or composite action) that
   starts the MQ containers, seeds them, and makes them available to

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# mq-dev-environment
+# mq-rest-admin-dev-environment
 
 Shared dockerized IBM MQ test environment for use across multiple
 repositories. Provides container lifecycle scripts, seed data, and
@@ -124,7 +124,7 @@ jobs:
 
       - name: Setup MQ
         id: mq
-        uses: wphillipmoore/mq-dev-environment/.github/actions/setup-mq@main
+        uses: wphillipmoore/mq-rest-admin-dev-environment/.github/actions/setup-mq@main
         with:
           verify: 'true'  # default; set 'false' to skip verification
 
@@ -152,7 +152,7 @@ Consuming repositories reference this repo as a sibling directory:
 
 ```text
 ~/dev/
-  mq-dev-environment/     # this repo
+  mq-rest-admin-dev-environment/     # this repo
   pymqrest/               # consuming repo
   mq-rest-admin/          # consuming repo
 ```
@@ -160,8 +160,8 @@ Consuming repositories reference this repo as a sibling directory:
 From a consuming repo, start the environment with:
 
 ```bash
-../mq-dev-environment/scripts/mq_start.sh
-../mq-dev-environment/scripts/mq_seed.sh
+../mq-rest-admin-dev-environment/scripts/mq_start.sh
+../mq-rest-admin-dev-environment/scripts/mq_seed.sh
 ```
 
 ## Reset workflow

--- a/docs/plans/2026-02-13-repository-design.md
+++ b/docs/plans/2026-02-13-repository-design.md
@@ -15,8 +15,8 @@
 - **Repository purpose**: Standalone shared repository for the dockerized IBM
   MQ test environment, consumed by multiple projects (pymqrest, mq-rest-admin,
   pymqpcf).
-- **Repository name**: `mq-dev-environment`.
-- **Consumption model (local)**: Sibling directory (`../mq-dev-environment`),
+- **Repository name**: `mq-rest-admin-dev-environment`.
+- **Consumption model (local)**: Sibling directory (`../mq-rest-admin-dev-environment`),
   same pattern as `../standards-and-conventions`.
 - **Consumption model (CI)**: Reusable GitHub Actions workflow or composite
   action (to be finalized during CI implementation).
@@ -67,7 +67,7 @@
 - Migrate Docker Compose file, mqwebuser.xml, lifecycle scripts, and MQSC
   seed files from pymqrest.
 - Rename `PYMQREST.*` object prefixes to a shared convention.
-- Update pymqrest to consume from `../mq-dev-environment` instead of bundling
+- Update pymqrest to consume from `../mq-rest-admin-dev-environment` instead of bundling
   scripts directly.
 - Implement CI workflow/composite action for GitHub Actions integration.
 - Enable integration tests in pymqrest CI using the shared action.
@@ -111,7 +111,7 @@
 
 #### Evidence cited
 
-- The sibling directory pattern (`../mq-dev-environment`) is already
+- The sibling directory pattern (`../mq-rest-admin-dev-environment`) is already
   established in this ecosystem: `../standards-and-conventions` is consumed
   the same way by both pymqrest and mq-rest-admin.
 - Shell scripts are callable from any build system. Maven can invoke them via
@@ -166,7 +166,7 @@
 
 ### Consumption: git submodule
 
-- **Description**: Add `mq-dev-environment` as a git submodule in each
+- **Description**: Add `mq-rest-admin-dev-environment` as a git submodule in each
   consuming repo.
 - **Reason not chosen**: Submodules create friction (developers forgetting
   `--recurse-submodules`, detached HEAD confusion, extra steps in CI
@@ -188,7 +188,7 @@
 ### Consumption: Makefile include
 
 - **Description**: Provide a Makefile that consuming repos include via
-  `include ../mq-dev-environment/Makefile`.
+  `include ../mq-rest-admin-dev-environment/Makefile`.
 - **Reason not chosen**: Not all consuming repos use Make. mq-rest-admin
   uses Maven. Adding Make as a required tool for MQ lifecycle management
   is an unnecessary dependency. The shell scripts are directly callable

--- a/docs/plans/open-decisions.md
+++ b/docs/plans/open-decisions.md
@@ -15,7 +15,7 @@ Track decisions for the shared MQ test environment repository.
 
 ## Repository identity
 
-- **Repository name**: `mq-dev-environment` (decided 2026-02-13, see
+- **Repository name**: `mq-rest-admin-dev-environment` (decided 2026-02-13, see
   `docs/plans/2026-02-13-repository-design.md`).
 - **License**: GPLv3.
 
@@ -40,7 +40,7 @@ Track decisions for the shared MQ test environment repository.
 
 ## Consumption model
 
-- **Local development**: Sibling directory `../mq-dev-environment` (decided
+- **Local development**: Sibling directory `../mq-rest-admin-dev-environment` (decided
   2026-02-13, see `docs/plans/2026-02-13-repository-design.md`).
 - **CI**: Composite action in this repo at
   `.github/actions/setup-mq/action.yml` (decided 2026-02-13).


### PR DESCRIPTION
## Summary

- Update all internal `mq-dev-environment` self-references to `mq-rest-admin-dev-environment` following the Phase 2 rename
- Phase 3, Step 7 of the repository rename plan

## Issue Linkage

- Ref #14
- Work is not complete until the issue is closed.

## Testing

- markdownlint

Docs-only: tests skipped

Files changed:
- `README.md` (5 references — heading, CI action path, directory layout, local dev commands)
- `CLAUDE.md` (2 references — project name, consumption model)
- `docs/plans/open-decisions.md` (2 references — repository name, local dev path)
- `docs/plans/2026-02-13-repository-design.md` (6 references — name, paths, submodule option, Makefile option)

## Notes

- Phase 3 post-rename PR. After this merges, `integration-tests` will be restored to CI gates rulesets on Go, Java, and Python repos.