### PR TITLE
docs: add MkDocs site, docs deployment workflow, and update repository profile

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,30 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: docs
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: "deploy: docs"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Deploy docs
+        uses: wphillipmoore/standard-actions/actions/docs-deploy@develop
+        with:
+          version-command: cat VERSION | cut -d. -f1,2

--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -26,9 +26,9 @@
 ## Repository profile
 
 - repository_type: infrastructure
-- versioning_scheme: none (not published as a package)
+- versioning_scheme: semver
 - branching_model: library-release
-- release_model: none (consumed via git reference)
+- release_model: tagged-release
 - supported_release_lines: current only
 - primary_language: shell
 

--- a/docs/site/docs/architecture/cross-qm-routing.md
+++ b/docs/site/docs/architecture/cross-qm-routing.md
@@ -1,0 +1,55 @@
+# Cross-QM Routing
+
+Both queue managers define transmission queues, remote queue
+definitions, and sender/receiver channel pairs for bidirectional
+message routing between QM1 and QM2.
+
+## QM1 to QM2
+
+| Object | Type | Description |
+| --- | --- | --- |
+| DEV.QM2.XMITQ | QLOCAL (XMITQ) | Transmission queue to QM2 |
+| DEV.REMOTE.TO.QM2 | QREMOTE | Routes to DEV.QLOCAL on QM2 |
+| QM1.TO.QM2 | SDR | Sender channel to QM2 (`qm2:1414`) |
+| QM2.TO.QM1 | RCVR | Receiver channel from QM2 |
+
+## QM2 to QM1
+
+| Object | Type | Description |
+| --- | --- | --- |
+| DEV.QM1.XMITQ | QLOCAL (XMITQ) | Transmission queue to QM1 |
+| DEV.REMOTE.TO.QM1 | QREMOTE | Routes to DEV.QLOCAL on QM1 |
+| QM2.TO.QM1 | SDR | Sender channel to QM1 (`qm1:1414`) |
+| QM1.TO.QM2 | RCVR | Receiver channel from QM1 |
+
+## Gateway routing
+
+Each queue manager defines a QM alias that enables the REST API on
+one queue manager to route MQSC commands to the other:
+
+| Queue Manager | QM Alias | Routes To | Via |
+| --- | --- | --- | --- |
+| QM1 | QM2 | QM2 | DEV.QM2.XMITQ |
+| QM2 | QM1 | QM1 | DEV.QM1.XMITQ |
+
+The QM alias is defined as a QREMOTE with an empty `RNAME`:
+
+```text
+DEFINE QREMOTE(QM2) RNAME('') RQMNAME('QM2') XMITQ(DEV.QM2.XMITQ)
+```
+
+This allows the REST API's `runCommandJSON` endpoint on QM1 to
+execute commands on QM2 by specifying `QM2` as the target queue
+manager, and vice versa.
+
+## Channel startup
+
+The sender channels are started automatically during seeding:
+
+```text
+START CHANNEL(QM1.TO.QM2)   -- on QM1
+START CHANNEL(QM2.TO.QM1)   -- on QM2
+```
+
+Both channels connect using the Docker network hostnames (`qm1`,
+`qm2`) on port 1414.

--- a/docs/site/docs/architecture/environment-contract.md
+++ b/docs/site/docs/architecture/environment-contract.md
@@ -1,0 +1,48 @@
+# Environment Contract
+
+Consuming repositories depend on these stable details. Changes to
+any of these values are breaking changes and require coordination
+with all consuming repos.
+
+## Connection details
+
+| Property | Value |
+| --- | --- |
+| Queue manager 1 | QM1 |
+| Queue manager 2 | QM2 |
+| QM1 REST API | `https://localhost:9443/ibmmq/rest/v2` |
+| QM2 REST API | `https://localhost:9444/ibmmq/rest/v2` |
+| QM1 MQ listener | `localhost:1414` |
+| QM2 MQ listener | `localhost:1415` |
+| Admin user | `mqadmin` / `mqadmin` |
+| Reader user | `mqreader` / `mqreader` |
+| Docker image | `icr.io/ibm-messaging/mq:latest` |
+| Docker network | `mq-dev-net` |
+
+## Seed objects
+
+Both queue managers receive a shared set of `DEV.*` objects. QM1 has
+the full set covering all major MQ object types; QM2 has a minimal
+subset plus cross-QM routing counterparts.
+
+See [Seed Data](../configuration/seed-data.md) for the complete
+object listing.
+
+## CI outputs
+
+The composite action exposes REST API base URLs as step outputs:
+
+| Output | Value |
+| --- | --- |
+| `qm1-rest-url` | `https://localhost:9443/ibmmq/rest/v2` |
+| `qm2-rest-url` | `https://localhost:9444/ibmmq/rest/v2` |
+
+See [CI Integration](../ci-integration.md) for usage details.
+
+## Consuming repositories
+
+- [pymqrest](https://github.com/wphillipmoore/pymqrest) — Python
+  wrapper for the MQ administrative REST API
+- [mq-rest-admin](https://github.com/wphillipmoore/mq-rest-admin) —
+  Java port of pymqrest
+- pymqpcf — Python wrapper for the MQ PCF API (planned)

--- a/docs/site/docs/ci-integration.md
+++ b/docs/site/docs/ci-integration.md
@@ -1,0 +1,67 @@
+# CI Integration
+
+This repository provides a composite action at
+`.github/actions/setup-mq/action.yml` for use in GitHub Actions
+workflows. The action starts the MQ containers, seeds them with
+test objects, and optionally verifies the environment.
+
+## Usage
+
+```yaml
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup MQ
+        id: mq
+        uses: wphillipmoore/mq-rest-admin-dev-environment/.github/actions/setup-mq@main
+        with:
+          verify: 'true'
+
+      # Use the outputs in subsequent steps
+      # ${{ steps.mq.outputs.qm1-rest-url }}
+      # ${{ steps.mq.outputs.qm2-rest-url }}
+```
+
+## Inputs
+
+| Input | Required | Default | Description |
+| --- | --- | --- | --- |
+| `project-name` | No | `mq-dev` | COMPOSE_PROJECT_NAME for container isolation |
+| `qm1-rest-port` | No | `9443` | Host port for QM1 REST API |
+| `qm2-rest-port` | No | `9444` | Host port for QM2 REST API |
+| `verify` | No | `true` | Run `mq_verify.sh` after seeding |
+
+## Outputs
+
+| Output | Value |
+| --- | --- |
+| `qm1-rest-url` | `https://localhost:<qm1-rest-port>/ibmmq/rest/v2` |
+| `qm2-rest-url` | `https://localhost:<qm2-rest-port>/ibmmq/rest/v2` |
+
+## What the action does
+
+1. **Start containers** — runs `scripts/mq_start.sh` with the
+   configured ports and project name
+2. **Seed objects** — runs `scripts/mq_seed.sh` to create all
+   `DEV.*` objects on both queue managers
+3. **Verify** (optional) — runs `scripts/mq_verify.sh` to confirm
+   all expected objects exist via the REST API
+
+## Port customization
+
+Use the `qm1-rest-port` and `qm2-rest-port` inputs to avoid port
+conflicts when running multiple MQ environments in the same
+workflow:
+
+```yaml
+- name: Setup MQ
+  id: mq
+  uses: wphillipmoore/mq-rest-admin-dev-environment/.github/actions/setup-mq@main
+  with:
+    project-name: 'my-tests'
+    qm1-rest-port: '19443'
+    qm2-rest-port: '19444'
+```

--- a/docs/site/docs/configuration/docker-compose.md
+++ b/docs/site/docs/configuration/docker-compose.md
@@ -1,0 +1,70 @@
+# Docker Compose
+
+The Docker Compose configuration is located at `config/docker-compose.yml`
+and defines two IBM MQ container services with REST API access.
+
+## Services
+
+### QM1
+
+| Property | Value |
+| --- | --- |
+| Image | `icr.io/ibm-messaging/mq:latest` |
+| Hostname | `qm1` |
+| MQ listener port | `1414` (host: `1414`) |
+| REST API port | `9443` (host: `9443`) |
+| Queue manager name | `QM1` |
+
+### QM2
+
+| Property | Value |
+| --- | --- |
+| Image | `icr.io/ibm-messaging/mq:latest` |
+| Hostname | `qm2` |
+| MQ listener port | `1414` (host: `1415`) |
+| REST API port | `9443` (host: `9444`) |
+| Queue manager name | `QM2` |
+
+## Environment variables
+
+Both services accept the same environment variables for port
+overrides:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `MQ_IMAGE` | `icr.io/ibm-messaging/mq:latest` | Container image |
+| `QM1_MQ_PORT` | `1414` | Host port for QM1 MQ listener |
+| `QM1_REST_PORT` | `9443` | Host port for QM1 REST API |
+| `QM2_MQ_PORT` | `1415` | Host port for QM2 MQ listener |
+| `QM2_REST_PORT` | `9444` | Host port for QM2 REST API |
+
+## Volumes
+
+Each queue manager has a dedicated named volume for persistent data:
+
+- `qm1data` — mounted at `/var/mqm` in the QM1 container
+- `qm2data` — mounted at `/var/mqm` in the QM2 container
+
+The `mqwebuser.xml` configuration file is bind-mounted read-only
+into both containers at the Liberty web server configuration path.
+
+## Health checks
+
+Both containers use the `dspmq` command as a health check:
+
+```yaml
+healthcheck:
+  test: ["CMD", "dspmq", "-m", "QM1"]  # or QM2
+  interval: 10s
+  timeout: 5s
+  retries: 12
+```
+
+The `mq_start.sh` script waits for both containers to report
+healthy before returning.
+
+## Network
+
+Both services share the `mq-dev-net` Docker network, which allows
+the containers to communicate using their hostnames (`qm1`, `qm2`).
+This is required for the cross-QM sender/receiver channels.

--- a/docs/site/docs/configuration/rest-api-users.md
+++ b/docs/site/docs/configuration/rest-api-users.md
@@ -1,0 +1,53 @@
+# REST API Users
+
+REST API authentication is configured through the `mqwebuser.xml`
+file located at `config/mqwebuser.xml`. This file is bind-mounted
+into both containers at the Liberty web server configuration path.
+
+## Users
+
+| User | Password | Role | Access |
+| --- | --- | --- | --- |
+| `mqadmin` | `mqadmin` | MQWebAdmin | Full administrative access |
+| `mqreader` | `mqreader` | MQWebAdminRO | Read-only access |
+
+Both users also have the `MQWebUser` role, which grants access to
+the MQ Console web UI.
+
+## Security roles
+
+The configuration defines roles for two Liberty applications:
+
+### MQ Console (`com.ibm.mq.console`)
+
+| Role | Users | Description |
+| --- | --- | --- |
+| MQWebAdmin | mqadmin | Full admin access to the console |
+| MQWebAdminRO | mqreader | Read-only console access |
+| MQWebUser | mqadmin, mqreader | General console access |
+
+### MQ REST API (`com.ibm.mq.rest`)
+
+| Role | Users | Description |
+| --- | --- | --- |
+| MQWebAdmin | mqadmin | Full admin access to REST endpoints |
+| MQWebAdminRO | mqreader | Read-only REST access |
+| MQWebUser | mqadmin, mqreader | General REST access |
+
+## Configuration file
+
+The `mqwebuser.xml` uses Liberty's basic registry:
+
+```xml
+<server>
+  <basicRegistry id="basic" realm="defaultRealm">
+    <user name="mqadmin" password="${env.MQ_ADMIN_PASSWORD}" />
+    <user name="mqreader" password="${env.MQ_READER_PASSWORD}" />
+  </basicRegistry>
+  ...
+</server>
+```
+
+Passwords are injected via environment variables set in the Docker
+Compose configuration (`MQ_ADMIN_PASSWORD` and
+`MQ_READER_PASSWORD`).

--- a/docs/site/docs/configuration/seed-data.md
+++ b/docs/site/docs/configuration/seed-data.md
@@ -1,0 +1,64 @@
+# Seed Data
+
+Seed data is defined as MQSC command files in the `seed/` directory.
+The `mq_seed.sh` script runs these files against the respective
+queue managers using `docker exec` and `runmqsc`.
+
+## Seed files
+
+| File | Target |
+| --- | --- |
+| `seed/base-qm1.mqsc` | QM1 |
+| `seed/base-qm2.mqsc` | QM2 |
+
+## QM1 objects
+
+QM1 has the full set of development objects covering all major MQ
+object types:
+
+| Object | Type | Notes |
+| --- | --- | --- |
+| DEV.DEAD.LETTER | QLOCAL | Dead-letter queue (set on QMGR) |
+| DEV.QLOCAL | QLOCAL | General-purpose local queue |
+| DEV.XMITQ | QLOCAL (XMITQ) | Transmission queue |
+| DEV.QREMOTE | QREMOTE | Routes to DEV.TARGET on QM1 |
+| DEV.QALIAS | QALIAS | Alias for DEV.QLOCAL |
+| DEV.QMODEL | QMODEL | Temporary-dynamic model queue |
+| DEV.TOPIC | TOPIC | Topic string `dev/topic` |
+| DEV.NAMELIST | NAMELIST | Contains DEV.QLOCAL |
+| DEV.SVRCONN | SVRCONN | Server-connection channel |
+| DEV.SDR | SDR | Sender channel |
+| DEV.RCVR | RCVR | Receiver channel |
+| DEV.LSTR | LISTENER | TCP listener on port 1415 |
+| DEV.PROC | PROCESS | Process definition |
+
+## QM2 objects
+
+QM2 has a minimal subset of development objects:
+
+| Object | Type | Notes |
+| --- | --- | --- |
+| DEV.DEAD.LETTER | QLOCAL | Dead-letter queue (set on QMGR) |
+| DEV.QLOCAL | QLOCAL | General-purpose local queue |
+| DEV.SVRCONN | SVRCONN | Server-connection channel |
+
+## Cross-QM objects
+
+Both queue managers define additional objects for bidirectional
+message routing. See
+[Cross-QM Routing](../architecture/cross-qm-routing.md) for
+details.
+
+## Security configuration
+
+Both queue managers disable connection authentication and channel
+authentication for containerized testing:
+
+```text
+ALTER QMGR CONNAUTH(' ') CHLAUTH(DISABLED)
+REFRESH SECURITY TYPE(CONNAUTH)
+```
+
+!!! warning
+    This configuration is for development and testing only. Never
+    use these settings in production.

--- a/docs/site/docs/development.md
+++ b/docs/site/docs/development.md
@@ -1,0 +1,70 @@
+# Development
+
+## Local directory structure
+
+Consuming repositories reference this repo as a sibling directory:
+
+```text
+~/dev/
+  mq-rest-admin-dev-environment/     # this repo
+  pymqrest/                          # consuming repo
+  mq-rest-admin/                     # consuming repo
+```
+
+## Starting the environment from a consuming repo
+
+From a consuming repository, start the environment using relative
+paths:
+
+```bash
+../mq-rest-admin-dev-environment/scripts/mq_start.sh
+../mq-rest-admin-dev-environment/scripts/mq_seed.sh
+```
+
+## Reset workflow
+
+To tear down the environment completely (including Docker volumes)
+and start fresh:
+
+```bash
+scripts/mq_reset.sh
+```
+
+`mq_reset.sh` runs `docker compose down -v`, which removes all
+container data. Use `mq_stop.sh` instead if you want to preserve
+queue manager state across restarts.
+
+## Adding seed objects
+
+Seed data is defined as MQSC commands in the `seed/` directory:
+
+- `seed/base-qm1.mqsc` — objects for QM1
+- `seed/base-qm2.mqsc` — objects for QM2
+
+To add a new object:
+
+1. Add the MQSC `DEFINE` command to the appropriate seed file
+2. Run `scripts/mq_reset.sh` to apply (or `mq_seed.sh` if using
+   `REPLACE`)
+3. Update `scripts/mq_verify.sh` if the new object should be
+   verified
+4. Update the seed data documentation
+
+## Environment variables
+
+The Docker Compose configuration supports port overrides via
+environment variables:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `MQ_IMAGE` | `icr.io/ibm-messaging/mq:latest` | Container image |
+| `QM1_MQ_PORT` | `1414` | Host port for QM1 MQ listener |
+| `QM1_REST_PORT` | `9443` | Host port for QM1 REST API |
+| `QM2_MQ_PORT` | `1415` | Host port for QM2 MQ listener |
+| `QM2_REST_PORT` | `9444` | Host port for QM2 REST API |
+
+Set these before running `mq_start.sh` to use non-default ports:
+
+```bash
+QM1_REST_PORT=19443 QM2_REST_PORT=19444 scripts/mq_start.sh
+```

--- a/docs/site/docs/getting-started.md
+++ b/docs/site/docs/getting-started.md
@@ -1,0 +1,52 @@
+# Getting Started
+
+## Prerequisites
+
+- **Docker**: Docker Desktop or Docker Engine with Compose v2
+- **curl**: For REST API health checks (pre-installed on macOS/Linux)
+
+## Quick start
+
+```bash
+scripts/mq_start.sh    # Start QM1 + QM2, wait for REST API readiness
+scripts/mq_seed.sh     # Run MQSC seed commands on both queue managers
+scripts/mq_verify.sh   # Verify seed objects exist via REST API
+```
+
+Once the environment is running, the REST APIs are available at:
+
+| Queue Manager | REST API URL |
+| --- | --- |
+| QM1 | `https://localhost:9443/ibmmq/rest/v2` |
+| QM2 | `https://localhost:9444/ibmmq/rest/v2` |
+
+Authenticate with `mqadmin` / `mqadmin` (full access) or
+`mqreader` / `mqreader` (read-only access).
+
+## Verify the environment
+
+Run the verification script to confirm all seed objects were created
+successfully:
+
+```bash
+scripts/mq_verify.sh
+```
+
+This queries the REST API on both queue managers and checks that
+each expected object exists.
+
+## Stop the environment
+
+```bash
+scripts/mq_stop.sh     # Stop and remove containers (preserves volumes)
+```
+
+To remove all container data and start fresh, use the reset workflow
+instead:
+
+```bash
+scripts/mq_reset.sh    # Stop, remove volumes, restart, and re-seed
+```
+
+See [Lifecycle Scripts](lifecycle-scripts.md) for full details on
+each script.

--- a/docs/site/docs/index.md
+++ b/docs/site/docs/index.md
@@ -1,0 +1,35 @@
+# mq-rest-admin-dev-environment
+
+Shared dockerized IBM MQ test environment for use across multiple
+repositories. Provides container lifecycle scripts, seed data, and
+a reusable GitHub Actions composite action for integration testing
+against a real MQ queue manager.
+
+## Consuming repositories
+
+- [pymqrest](https://github.com/wphillipmoore/pymqrest) — Python
+  wrapper for the MQ administrative REST API
+- [mq-rest-admin](https://github.com/wphillipmoore/mq-rest-admin) —
+  Java port of pymqrest
+- pymqpcf — Python wrapper for the MQ PCF API (planned)
+
+## What this repo provides
+
+- **Two queue managers** (QM1 and QM2) running in Docker containers
+  with REST API access enabled
+- **Seed data** covering all major MQ object types (queues, channels,
+  topics, namelists, processes, listeners)
+- **Cross-QM routing** with bidirectional sender/receiver channel
+  pairs and gateway QM aliases for REST API command routing
+- **Lifecycle scripts** for starting, seeding, verifying, resetting,
+  and stopping the environment
+- **CI composite action** for use in GitHub Actions workflows
+
+## Quick links
+
+- [Getting Started](getting-started.md) — prerequisites and quick
+  start
+- [Environment Contract](architecture/environment-contract.md) —
+  stable ports, credentials, and URLs
+- [CI Integration](ci-integration.md) — composite action usage
+- [Lifecycle Scripts](lifecycle-scripts.md) — script reference

--- a/docs/site/docs/lifecycle-scripts.md
+++ b/docs/site/docs/lifecycle-scripts.md
@@ -1,0 +1,101 @@
+# Lifecycle Scripts
+
+All lifecycle scripts are located in the `scripts/` directory. They
+manage the Docker container lifecycle for the MQ development
+environment.
+
+## Script reference
+
+### mq_start.sh
+
+Starts the QM1 and QM2 containers and waits for both REST APIs to
+become ready.
+
+```bash
+scripts/mq_start.sh
+```
+
+The script:
+
+1. Runs `docker compose up -d` using `config/docker-compose.yml`
+2. Waits for container health checks to pass
+3. Polls the REST API endpoints until they respond
+
+### mq_seed.sh
+
+Runs the MQSC seed scripts against both queue managers to create
+all development objects.
+
+```bash
+scripts/mq_seed.sh
+```
+
+The script:
+
+1. Copies `seed/base-qm1.mqsc` into the QM1 container
+2. Runs `runmqsc QM1` with the seed file
+3. Copies `seed/base-qm2.mqsc` into the QM2 container
+4. Runs `runmqsc QM2` with the seed file
+
+### mq_verify.sh
+
+Verifies that all expected seed objects exist by querying the REST
+API on both queue managers.
+
+```bash
+scripts/mq_verify.sh
+```
+
+The script checks each object type (queues, channels, topics, etc.)
+and reports success or failure for each.
+
+### mq_reset.sh
+
+Stops containers, removes Docker volumes, and restarts the
+environment cleanly.
+
+```bash
+scripts/mq_reset.sh
+```
+
+The script runs `docker compose down -v` to remove all container
+data, then calls `mq_start.sh` and `mq_seed.sh` to rebuild the
+environment from scratch.
+
+!!! warning
+    This removes all queue manager state including any messages
+    in queues. Use `mq_stop.sh` if you want to preserve state.
+
+### mq_stop.sh
+
+Stops and removes the containers but preserves the named Docker
+volumes.
+
+```bash
+scripts/mq_stop.sh
+```
+
+Queue manager state is retained in the `qm1data` and `qm2data`
+volumes and will be available on the next `mq_start.sh`.
+
+## Typical workflows
+
+### First-time setup
+
+```bash
+scripts/mq_start.sh
+scripts/mq_seed.sh
+scripts/mq_verify.sh
+```
+
+### Daily restart
+
+```bash
+scripts/mq_start.sh    # Volumes preserved, no re-seed needed
+```
+
+### Clean reset
+
+```bash
+scripts/mq_reset.sh    # Removes volumes and re-seeds
+```

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -1,0 +1,66 @@
+site_name: mq-rest-admin-dev-environment
+site_url: https://wphillipmoore.github.io/mq-rest-admin-dev-environment/
+site_description: Shared dockerized IBM MQ test environment for integration testing across the mq-rest-admin project family
+repo_url: https://github.com/wphillipmoore/mq-rest-admin-dev-environment
+repo_name: mq-rest-admin-dev-environment
+edit_uri: ""
+
+strict: true
+
+docs_dir: docs
+
+theme:
+  name: material
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - content.code.copy
+    - search.highlight
+    - search.suggest
+  palette:
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+
+extra:
+  version:
+    provider: mike
+
+plugins:
+  - search
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - tables
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - Configuration:
+      - Docker Compose: configuration/docker-compose.md
+      - Seed Data: configuration/seed-data.md
+      - REST API Users: configuration/rest-api-users.md
+  - Architecture:
+      - Environment Contract: architecture/environment-contract.md
+      - Cross-QM Routing: architecture/cross-qm-routing.md
+  - CI Integration: ci-integration.md
+  - Lifecycle Scripts: lifecycle-scripts.md
+  - Development: development.md


### PR DESCRIPTION
# Pull Request

## Summary

- Add MkDocs documentation site with Material theme, mike versioning, docs deployment workflow, and updated repository profile

## Issue Linkage

- Fixes #19

## Testing

Docs-only: tests skipped

Changed files:
- .github/workflows/docs.yml
- docs/repository-standards.md
- docs/site/docs/architecture/cross-qm-routing.md
- docs/site/docs/architecture/environment-contract.md
- docs/site/docs/ci-integration.md
- docs/site/docs/configuration/docker-compose.md
- docs/site/docs/configuration/rest-api-users.md
- docs/site/docs/configuration/seed-data.md
- docs/site/docs/development.md
- docs/site/docs/getting-started.md
- docs/site/docs/index.md
- docs/site/docs/lifecycle-scripts.md
- docs/site/mkdocs.yml

## Notes

- Also addresses the documentation deployment portion of #21 (Ref #21)
