### PR TITLE
fix: update consuming repos to language-specific library names

### DIFF
--- a/docs/site/docs/architecture/environment-contract.md
+++ b/docs/site/docs/architecture/environment-contract.md
@@ -1,8 +1,8 @@
 # Environment Contract
 
-Consuming repositories depend on these stable details. Changes to
-any of these values are breaking changes and require coordination
-with all consuming repos.
+The language-specific libraries depend on these stable details.
+Changes to any of these values are breaking changes and require
+coordination with all language libraries.
 
 ## Connection details
 
@@ -39,10 +39,13 @@ The composite action exposes REST API base URLs as step outputs:
 
 See [CI Integration](../ci-integration.md) for usage details.
 
-## Consuming repositories
+## Language libraries
 
-- [pymqrest](https://github.com/wphillipmoore/pymqrest) — Python
-  wrapper for the MQ administrative REST API
-- [mq-rest-admin](https://github.com/wphillipmoore/mq-rest-admin) —
-  Java port of pymqrest
-- pymqpcf — Python wrapper for the MQ PCF API (planned)
+This environment is used by the language-specific libraries in the
+mq-rest-admin project:
+
+- [mq-rest-admin-python](https://github.com/wphillipmoore/mq-rest-admin-python)
+- [mq-rest-admin-java](https://github.com/wphillipmoore/mq-rest-admin-java)
+- [mq-rest-admin-go](https://github.com/wphillipmoore/mq-rest-admin-go)
+- [mq-rest-admin-ruby](https://github.com/wphillipmoore/mq-rest-admin-ruby)
+- [mq-rest-admin-rust](https://github.com/wphillipmoore/mq-rest-admin-rust)

--- a/docs/site/docs/development.md
+++ b/docs/site/docs/development.md
@@ -2,18 +2,20 @@
 
 ## Local directory structure
 
-Consuming repositories reference this repo as a sibling directory:
+The language-specific libraries reference this repo as a sibling
+directory:
 
 ```text
 ~/dev/
   mq-rest-admin-dev-environment/     # this repo
-  pymqrest/                          # consuming repo
-  mq-rest-admin/                     # consuming repo
+  mq-rest-admin-python/              # language library
+  mq-rest-admin-java/                # language library
+  mq-rest-admin-go/                  # language library
 ```
 
-## Starting the environment from a consuming repo
+## Starting the environment from a language library
 
-From a consuming repository, start the environment using relative
+From a language library repo, start the environment using relative
 paths:
 
 ```bash

--- a/docs/site/docs/index.md
+++ b/docs/site/docs/index.md
@@ -5,13 +5,16 @@ repositories. Provides container lifecycle scripts, seed data, and
 a reusable GitHub Actions composite action for integration testing
 against a real MQ queue manager.
 
-## Consuming repositories
+## Language libraries
 
-- [pymqrest](https://github.com/wphillipmoore/pymqrest) — Python
-  wrapper for the MQ administrative REST API
-- [mq-rest-admin](https://github.com/wphillipmoore/mq-rest-admin) —
-  Java port of pymqrest
-- pymqpcf — Python wrapper for the MQ PCF API (planned)
+This environment is used by the language-specific libraries in the
+mq-rest-admin project:
+
+- [mq-rest-admin-python](https://github.com/wphillipmoore/mq-rest-admin-python)
+- [mq-rest-admin-java](https://github.com/wphillipmoore/mq-rest-admin-java)
+- [mq-rest-admin-go](https://github.com/wphillipmoore/mq-rest-admin-go)
+- [mq-rest-admin-ruby](https://github.com/wphillipmoore/mq-rest-admin-ruby)
+- [mq-rest-admin-rust](https://github.com/wphillipmoore/mq-rest-admin-rust)
 
 ## What this repo provides
 


### PR DESCRIPTION
# Pull Request

## Summary

- Update consuming repos to language-specific library names (mq-rest-admin-python, -java, -go, -ruby, -rust)

## Issue Linkage

- Ref #19

## Testing

Docs-only: tests skipped

Changed files:
- docs/site/docs/architecture/environment-contract.md
- docs/site/docs/development.md
- docs/site/docs/index.md

## Notes

- -
