### PR TITLE
docs: replace stale script references with st-* commands

### DIFF
--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -67,7 +67,7 @@ submission. Do not construct commit messages or PR bodies manually.
 ### Committing
 
 ```bash
-scripts/dev/commit.sh \
+st-commit \
   --type TYPE --message MESSAGE --agent AGENT \
   [--scope SCOPE] [--body BODY]
 ```
@@ -86,7 +86,7 @@ the result.
 ### Submitting PRs
 
 ```bash
-scripts/dev/submit-pr.sh \
+st-submit-pr \
   --issue NUMBER --summary TEXT \
   [--linkage KEYWORD] [--title TEXT] \
   [--notes TEXT] [--docs-only] [--dry-run]


### PR DESCRIPTION
# Pull Request

## Summary

- Replace stale script references with st-* commands

## Issue Linkage

- Ref wphillipmoore/standards-and-conventions#311

## Testing

Docs-only: tests skipped

Changed files:
- docs/repository-standards.md

## Notes

- -