### PR TITLE
docs: add Releases nav section to documentation site

### DIFF
--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -53,6 +53,10 @@ markdown_extensions:
 
 nav:
   - Home: index.md
+  - Releases:
+      - Changelog: changelog.md
+      - Release Notes:
+          - releases/index.md
   - Getting Started: getting-started.md
   - Configuration:
       - Docker Compose: configuration/docker-compose.md


### PR DESCRIPTION
# Pull Request

## Summary

- Add Releases nav tab to mkdocs.yml, matching standardized structure from common and language repos

## Issue Linkage

- Fixes #56

## Testing



## Notes

- -