### PR TITLE
fix: set LTPA cookie name declaratively in mqwebuser.xml

### DIFF
--- a/config/mqwebuser.xml
+++ b/config/mqwebuser.xml
@@ -1,4 +1,6 @@
 <server>
+  <webAppSecurity ltpaCookieName="LtpaToken2" />
+
   <basicRegistry id="basic" realm="defaultRealm">
     <user name="mqadmin" password="${env.MQ_ADMIN_PASSWORD}" />
     <user name="mqreader" password="${env.MQ_READER_PASSWORD}" />

--- a/scripts/mq_start.sh
+++ b/scripts/mq_start.sh
@@ -42,21 +42,5 @@ wait_for_qm() {
   done
 }
 
-set_stable_ltpa_cookie_name() {
-  local service_name="$1"
-  echo "Setting stable LTPA cookie name on ${service_name}..."
-  docker compose -f config/docker-compose.yml exec -T "${service_name}" \
-    setmqweb properties -k ltpaCookieName -v LtpaToken2
-  docker compose -f config/docker-compose.yml exec -T "${service_name}" endmqweb
-  docker compose -f config/docker-compose.yml exec -T "${service_name}" strmqweb
-}
-
-wait_for_qm "https://localhost:${qm1_rest_port}/ibmmq/rest/v2" "QM1"
-wait_for_qm "https://localhost:${qm2_rest_port}/ibmmq/rest/v2" "QM2"
-
-set_stable_ltpa_cookie_name "qm1"
-set_stable_ltpa_cookie_name "qm2"
-
-# Wait for web servers to restart after cookie name change.
 wait_for_qm "https://localhost:${qm1_rest_port}/ibmmq/rest/v2" "QM1"
 wait_for_qm "https://localhost:${qm2_rest_port}/ibmmq/rest/v2" "QM2"


### PR DESCRIPTION
# Pull Request

## Summary

- Set LTPA cookie name declaratively in mqwebuser.xml instead of runtime setmqweb command that fails on read-only mount

## Issue Linkage

- Fixes #79

## Testing



## Notes

- -