### PR TITLE
chore: use .markdownlintignore for lint exclusions

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,2 @@
+CHANGELOG.md
+releases/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ scripts/mq_stop.sh           # Stop and remove containers
 
 ```bash
 scripts/mq_verify.sh         # Verify MQ environment is correctly seeded
-markdownlint '**/*.md' --ignore node_modules   # Lint documentation
+markdownlint . --ignore node_modules            # Lint documentation
 ```
 
 ## Architecture

--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -39,7 +39,7 @@
 scripts/mq_verify.sh
 
 # Lint documentation
-markdownlint '**/*.md' --ignore node_modules
+markdownlint . --ignore node_modules
 ```
 
 ## Tooling requirement


### PR DESCRIPTION
# Pull Request

## Summary

- Add .markdownlintignore to exclude CHANGELOG.md and releases/
- Change documented validation command from `markdownlint '**/*.md'` to `markdownlint .` in CLAUDE.md and docs/repository-standards.md

## Issue Linkage

- Ref wphillipmoore/mq-rest-admin-common#190

## Testing

- markdownlint

## Notes

- Part of cross-repo rollout across all managed repositories