### PR TITLE
chore: install standard-tooling plugin via marketplace

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "extraKnownMarketplaces": {
+    "standard-tooling-marketplace": {
+      "source": {
+        "source": "github",
+        "repo": "wphillipmoore/standard-tooling-plugin"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "standard-tooling@standard-tooling-marketplace": true
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,7 +228,8 @@ st-commit --type fix --message "correct container startup" --agent claude
 
 - `--type` (required): `feat|fix|docs|style|refactor|test|chore|ci|build`
 - `--message` (required): commit description
-- `--agent` (required): `claude` or `codex` — resolves the correct `Co-Authored-By` identity
+- `--agent` (required): `claude` or `codex` — resolves the correct
+  `Co-Authored-By` identity
 - `--scope` (optional): conventional commit scope
 - `--body` (optional): detailed commit body
 


### PR DESCRIPTION
# Pull Request

## Summary

- Install standard-tooling plugin via marketplace configuration

## Issue Linkage

- Fixes #85

## Testing



## Notes

- -