### PR TITLE
Container-first validation: containerise lint.sh

### DIFF
--- a/scripts/dev/lint.sh
+++ b/scripts/dev/lint.sh
@@ -2,15 +2,12 @@
 set -euo pipefail
 # Tier 1 — Lint
 
-files=$(find scripts -type f \( -name '*.sh' -o -path '*/git-hooks/*' \) | sort)
-if [ -n "$files" ]; then
-  echo "$files" | xargs shellcheck
-else
-  echo "No shell scripts found."
-fi
+export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-dev-python:3.14}"
+export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-files=\$(find scripts -type f \\( -name '*.sh' -o -path '*/git-hooks/*' \\) | sort) && if [ -n \"\$files\" ]; then echo \"\$files\" | xargs shellcheck; else echo 'No shell scripts found.'; fi && actionlint}"
 
-if command -v actionlint >/dev/null 2>&1; then
-  actionlint
-else
-  echo "actionlint not found — skipping workflow lint."
+if ! command -v docker-test >/dev/null 2>&1; then
+  echo "ERROR: docker-test not found on PATH." >&2
+  echo "Set up standard-tooling: export PATH=../standard-tooling/scripts/bin:\$PATH" >&2
+  exit 1
 fi
+exec docker-test


### PR DESCRIPTION
## Summary
- Update `lint.sh` to run shellcheck and actionlint inside a container via `docker-test`
- Use explicit `DOCKER_DEV_IMAGE=dev-python:3.14` (this repo has no language markers)
- Require `docker-test` on PATH with clear error message

## Test plan
- [ ] Run `scripts/dev/lint.sh` — shellcheck and actionlint run in container
- [ ] Verify clear error when `docker-test` not on PATH

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)