### PR TITLE
chore: ban MEMORY.md usage in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,14 @@ working with code in this repository.
 <!-- include: docs/standards-and-conventions.md -->
 <!-- include: docs/repository-standards.md -->
 
+## Auto-memory policy
+
+**Do NOT use MEMORY.md.** Never write to MEMORY.md or any file under the
+memory directory. All behavioral rules, conventions, and workflow instructions
+belong in managed, version-controlled documentation (CLAUDE.md, AGENTS.md,
+skills, or docs/). If you want to persist something, tell the human what you
+would save and let them decide where it belongs.
+
 ## Project Overview
 
 Shared dockerized IBM MQ test environment for use across multiple


### PR DESCRIPTION
# Pull Request

## Summary

- Ban MEMORY.md usage in CLAUDE.md to prevent inconsistent cross-repo behavior

## Issue Linkage

- Fixes wphillipmoore/standards-and-conventions#347

## Testing

- Verify CLAUDE.md contains the auto-memory policy section

## Notes

-