### PR TITLE
ci: use dev-docs container for docs CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,6 +18,7 @@ jobs:
   deploy:
     name: "deploy: docs"
     runs-on: ubuntu-latest
+    container: ghcr.io/wphillipmoore/dev-docs:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -25,6 +26,6 @@ jobs:
           fetch-depth: 0
 
       - name: Deploy docs
-        uses: wphillipmoore/standard-actions/actions/docs-deploy@v1.1
+        uses: wphillipmoore/standard-actions/actions/docs-deploy@develop
         with:
           version-command: cat VERSION | cut -d. -f1,2


### PR DESCRIPTION
# Pull Request

## Summary

- Switch docs workflow to run inside ghcr.io/wphillipmoore/dev-docs:latest container and pin docs-deploy action to @develop.

## Issue Linkage

- Fixes #94

## Testing



## Notes

- -