### PR TITLE
chore(ci): migrate standard-actions refs from @develop to @v1.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Validate standards
-        uses: wphillipmoore/standard-actions/actions/standards-compliance@develop
+        uses: wphillipmoore/standard-actions/actions/standards-compliance@v1.3
 
   shellcheck:
     name: "ci: shellcheck"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,6 +26,6 @@ jobs:
           fetch-depth: 0
 
       - name: Deploy docs
-        uses: wphillipmoore/standard-actions/actions/docs-deploy@develop
+        uses: wphillipmoore/standard-actions/actions/docs-deploy@v1.3
         with:
           version-command: cat VERSION | cut -d. -f1,2


### PR DESCRIPTION
# Pull Request

## Summary

- Migrate standard-actions refs from @develop to @v1.3

## Issue Linkage

- Closes #98

## Testing



## Notes

- Pins ci-security.yml (in ci.yml) and docs-deploy (in docs.yml) to @v1.3 rolling minor tag. Existing @v1.1 pins on trivy-image, publish/tag-and-release, publish/version-bump-pr are intentionally left as-is per migration plan in standard-actions#145.