### PR TITLE
chore: bump standard-actions pins from v1.1 to v1.4

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Tag and release
         if: steps.tag_check.outputs.exists == 'false'
-        uses: wphillipmoore/standard-actions/actions/publish/tag-and-release@v1.1
+        uses: wphillipmoore/standard-actions/actions/publish/tag-and-release@v1.4
         with:
           version: ${{ steps.version.outputs.version }}
           release-title: mq-rest-admin-dev-environment
@@ -64,7 +64,7 @@ jobs:
 
       - name: Version bump PR
         if: steps.tag_check.outputs.exists == 'false'
-        uses: wphillipmoore/standard-actions/actions/publish/version-bump-pr@v1.1
+        uses: wphillipmoore/standard-actions/actions/publish/version-bump-pr@v1.4
         with:
           current-version: ${{ steps.version.outputs.version }}
           version-file: VERSION

--- a/.github/workflows/trivy-image.yml
+++ b/.github/workflows/trivy-image.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Scan MQ container image
-        uses: wphillipmoore/standard-actions/actions/security/trivy@v1.1
+        uses: wphillipmoore/standard-actions/actions/security/trivy@v1.4
         with:
           scan-type: image
           scan-ref: icr.io/ibm-messaging/mq:latest


### PR DESCRIPTION
# Pull Request

## Summary

- Bump all standard-actions pins from v1.1 to v1.4 (tag-and-release, version-bump-pr, trivy)

## Issue Linkage

- Ref #104

## Testing



## Notes

- -