### PR TITLE
chore: remove stale include directives and add standards reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,8 @@
 # Agent Instructions
 
-<!-- include: docs/standards-and-conventions.md -->
-<!-- include: ./docs/repository-standards.md -->
+**Standards reference**: <https://github.com/wphillipmoore/standards-and-conventions>
+— active standards documentation lives in the standard-tooling repository under `docs/`.
+Repository profile: `standard-tooling.toml`.
 
 ## User Overrides (Optional)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,8 +3,9 @@
 This file provides guidance to Claude Code (claude.ai/code) when
 working with code in this repository.
 
-<!-- include: docs/standards-and-conventions.md -->
-<!-- include: docs/repository-standards.md -->
+**Standards reference**: <https://github.com/wphillipmoore/standards-and-conventions>
+— active standards documentation lives in the standard-tooling repository under `docs/`.
+Repository profile: `standard-tooling.toml`.
 
 ## Auto-memory policy
 


### PR DESCRIPTION
# Pull Request

## Summary

- Remove stale include directives from AGENTS.md and CLAUDE.md and replace them with a standards reference directive pointing to the standards-and-conventions repository.

## Issue Linkage

- Ref #438

## Testing



## Notes

- -