### PR TITLE
chore: delete stale st-config.toml

### DIFF
--- a/st-config.toml
+++ b/st-config.toml
@@ -1,2 +1,0 @@
-[standard-tooling]
-tag = "v1.4"


### PR DESCRIPTION
# Pull Request

## Summary

- Delete the last remaining st-config.toml — standard-tooling now reads standard-tooling.toml

## Issue Linkage

- Ref #363

## Testing



## Notes

- Last remaining st-config.toml in the fleet. Part of the standard-tooling.toml migration (wphillipmoore/standard-tooling#363 Phase 4).