### PR TITLE
ci(workflows): migrate CI/CD workflows to standard-actions v1.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,29 +1,39 @@
-name: CI - Test and Validate
+name: CI
 
 on:
   pull_request:
+  workflow_call:
+    inputs:
+      run-security:
+        type: string
+        default: "true"
+      run-release:
+        type: string
+        default: "true"
 
 permissions:
   contents: read
-  security-events: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  security-and-standards:
-    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.4
-    permissions:
-      contents: read
-      security-events: write
-    with:
-      language: shell
-      run-codeql: 'false'
+  common:
+    name: "quality / common"
+    runs-on: ubuntu-latest
+    container: ghcr.io/wphillipmoore/dev-base:latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Run common quality checks
+        run: st-validate --check common
 
   shellcheck:
-    name: "ci: shellcheck"
+    name: "quality / shellcheck"
     runs-on: ubuntu-latest
+    container: ghcr.io/wphillipmoore/dev-base:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -38,14 +48,28 @@ jobs:
           fi
 
   actionlint:
-    name: "ci: actionlint"
+    name: "quality / actionlint"
     runs-on: ubuntu-latest
+    container: ghcr.io/wphillipmoore/dev-base:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Install actionlint
-        run: bash <(curl -s https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-
       - name: Run actionlint
-        run: ./actionlint
+        run: actionlint
+
+  security:
+    if: ${{ inputs.run-security != 'false' }}
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.5
+    permissions:
+      contents: read
+      security-events: write
+    with:
+      language: shell
+      run-codeql: "false"
+
+  release:
+    if: ${{ inputs.run-release != 'false' }}
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-release.yml@v1.5
+    permissions:
+      contents: read

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,6 +26,7 @@ jobs:
           fetch-depth: 0
 
       - name: Deploy docs
-        uses: wphillipmoore/standard-actions/actions/docs-deploy@v1.4
+        uses: wphillipmoore/standard-actions/actions/docs-deploy@v1.5
         with:
-          version-command: cat VERSION | cut -d. -f1,2
+          version-command: st-version show --major-minor
+          checkout-common: "true"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,66 +9,28 @@ permissions:
   contents: write
   pull-requests: write
 
-concurrency:
-  group: publish
-  cancel-in-progress: false
-
 jobs:
   publish:
-    name: "publish: release"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
+    uses: wphillipmoore/standard-actions/.github/workflows/publish-release.yml@v1.5
+    permissions:
+      contents: write
+      pull-requests: write
+    with:
+      ecosystem: none
+      version-command: st-version show
+      release-title: mq-rest-admin-dev-environment
+      release-notes: |
+        ## mq-rest-admin-dev-environment
 
-      - name: Extract version
-        id: version
-        run: |
-          version=$(cat VERSION)
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "tag=v$version" >> "$GITHUB_OUTPUT"
+        Shared MQ development environment with Docker Compose, seed scripts, and CI actions.
 
-      - name: Check if tag already exists
-        id: tag_check
-        run: |
-          if git rev-parse "${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
+        ## Links
 
-      - name: Tag and release
-        if: steps.tag_check.outputs.exists == 'false'
-        uses: wphillipmoore/standard-actions/actions/publish/tag-and-release@v1.4
-        with:
-          version: ${{ steps.version.outputs.version }}
-          release-title: mq-rest-admin-dev-environment
-          release-notes: |
-            ## mq-rest-admin-dev-environment v${{ steps.version.outputs.version }}
-
-            Shared MQ development environment with Docker Compose, seed scripts, and CI actions.
-
-            ## Links
-
-            - [Documentation](https://wphillipmoore.github.io/mq-rest-admin-dev-environment/)
-
-      - name: Generate app token for bump PR
-        if: steps.tag_check.outputs.exists == 'false'
-        id: app-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-
-      - name: Version bump PR
-        if: steps.tag_check.outputs.exists == 'false'
-        uses: wphillipmoore/standard-actions/actions/publish/version-bump-pr@v1.4
-        with:
-          current-version: ${{ steps.version.outputs.version }}
-          version-file: VERSION
-          version-regex: '^.*$'
-          version-replacement: '{version}'
-          develop-version-command: cat
-          app-token: ${{ steps.app-token.outputs.token }}
+        - [Documentation](https://wphillipmoore.github.io/mq-rest-admin-dev-environment/)
+      version-file: VERSION
+      version-regex: '^.*$'
+      version-replacement: '{version}'
+      develop-version-command: st-version show
+    secrets:
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/trivy-image.yml
+++ b/.github/workflows/trivy-image.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Scan MQ container image
-        uses: wphillipmoore/standard-actions/actions/security/trivy@v1.4
+        uses: wphillipmoore/standard-actions/actions/security/trivy@v1.5
         with:
           scan-type: image
           scan-ref: icr.io/ibm-messaging/mq:latest

--- a/standard-tooling.toml
+++ b/standard-tooling.toml
@@ -9,5 +9,9 @@ primary-language = "shell"
 claude = "Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@users.noreply.github.com>"
 codex = "Co-Authored-By: wphillipmoore-codex <255923655+wphillipmoore-codex@users.noreply.github.com>"
 
+[ci]
+versions = ["latest"]
+integration-tests = false
+
 [dependencies]
 standard-tooling = "v1.4"


### PR DESCRIPTION
# Pull Request

## Summary

- Migrate CI/CD workflows to standard-actions v1.5

## Issue Linkage

- Ref #117

## Testing



## Notes

- Ref #117

## Summary

- Replace bespoke CI with v1.5 reusable workflows: ci-security,
  ci-release, plus bespoke quality/common, quality/shellcheck,
  and quality/actionlint jobs running in dev-base container
- Migrate publish workflow from bespoke steps to reusable
  publish-release.yml with ecosystem: none
- Bump docs-deploy and trivy actions from v1.4 to v1.5
- Replace inline version commands (cat VERSION) with st-version show
- Add [ci] section to standard-tooling.toml with versions = ["latest"]

## Test plan

- [ ] quality/common runs st-validate --check common successfully
- [ ] quality/shellcheck and quality/actionlint pass
- [ ] security/trivy, security/semgrep, security/standards pass
- [ ] release/version-bump passes
- [ ] st-github-config apply creates CI gates ruleset after merge