### PR TITLE
fix(ci): pass boolean to ci-security reusable workflow inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,8 @@ jobs:
     uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.5
     with:
       language: shell
-      run-standards: ${{ inputs.run-security || true }}
-      run-security: ${{ inputs.run-security || true }}
+      run-standards: ${{ inputs.run-release != 'false' }}
+      run-security: ${{ inputs.run-security != 'false' }}
       run-codeql: false
     permissions:
       contents: read


### PR DESCRIPTION
# Pull Request

## Summary

- Fix string-vs-boolean type mismatch that silently breaks security CI jobs

## Issue Linkage

- Ref wphillipmoore/standard-tooling#632

## Testing



## Notes

- Root-caused during fleet cleanup (standard-tooling#626). Security jobs were never spawning due to type mismatch.