### PR TITLE
chore: migrate to mq-rest-admin-project org and vergil tooling

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,13 +1,13 @@
 {
   "extraKnownMarketplaces": {
-    "standard-tooling-marketplace": {
+    "vergil-marketplace": {
       "source": {
         "source": "github",
-        "repo": "wphillipmoore/standard-tooling-plugin"
+        "repo": "vergil-project/vergil-plugin"
       }
     }
   },
   "enabledPlugins": {
-    "standard-tooling@standard-tooling-marketplace": true
+    "vergil@vergil-marketplace": true
   }
 }

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-# Source: wphillipmoore/standard-tooling/.github/ISSUE_TEMPLATE/config.yml
+# Source: vergil-project/vergil-tooling/.github/ISSUE_TEMPLATE/config.yml
 # Do not modify repo-local copies — update the source and re-sync.
 #
 blank_issues_enabled: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,2 +1,2 @@
 > **Do not create PRs manually.**
-> Use [`st-submit-pr`](https://wphillipmoore.github.io/standard-tooling/reference/dev/submit-pr/).
+> Use [`vrg-submit-pr`](https://vergil-project.github.io/vergil-tooling/reference/dev/submit-pr/).

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,4 +1,4 @@
-# https://github.com/wphillipmoore/standard-actions/blob/develop/.github/workflows/README.md
+# https://github.com/vergil-project/vergil-actions/blob/develop/.github/workflows/README.md
 name: CD
 
 on:
@@ -14,16 +14,18 @@ permissions:
 
 jobs:
   docs:
-    uses: wphillipmoore/standard-actions/.github/workflows/cd-docs.yml@v1.5
+    uses: vergil-project/vergil-actions/.github/workflows/cd-docs.yml@v2.0
     with:
       pre-deploy-command: >-
         git clone --depth 1 --branch develop
-        https://github.com/wphillipmoore/mq-rest-admin-common.git
+        https://github.com/mq-rest-admin-project/mq-rest-admin-common.git
         .mq-rest-admin-common
     permissions:
       contents: write
 
   release:
     if: github.ref == 'refs/heads/main'
-    uses: wphillipmoore/standard-actions/.github/workflows/cd-release.yml@v1.5
-    secrets: inherit
+    uses: vergil-project/vergil-actions/.github/workflows/cd-release.yml@v2.0
+    secrets:
+      APP_CLIENT_ID: ${{ secrets.APP_CLIENT_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# https://github.com/wphillipmoore/standard-actions/blob/develop/.github/workflows/README.md
+# https://github.com/vergil-project/vergil-actions/blob/develop/.github/workflows/README.md
 name: CI
 
 on:
@@ -21,14 +21,14 @@ concurrency:
 
 jobs:
   quality:
-    uses: wphillipmoore/standard-actions/.github/workflows/ci-quality.yml@v1.5
+    uses: vergil-project/vergil-actions/.github/workflows/ci-quality.yml@v2.0
     with:
       language: shell
       versions: '["latest"]'
       container-suffix: base
 
   security:
-    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.5
+    uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v2.0
     with:
       language: shell
       run-standards: ${{ inputs.run-release != 'false' }}
@@ -39,7 +39,7 @@ jobs:
       security-events: write
 
   version:
-    uses: wphillipmoore/standard-actions/.github/workflows/ci-version-bump.yml@v1.5
+    uses: vergil-project/vergil-actions/.github/workflows/ci-version-bump.yml@v2.0
     with:
       language: shell
       run-release: ${{ inputs.run-release != 'false' }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,8 @@
 # Agent Instructions
 
-**Standards reference**: <https://github.com/wphillipmoore/standards-and-conventions>
-— active standards documentation lives in the standard-tooling repository under `docs/`.
-Repository profile: `standard-tooling.toml`.
+**Standards reference**: <https://github.com/vergil-project/vergil-tooling>
+— active standards documentation lives in the vergil-tooling repository under `docs/`.
+Repository profile: `vergil.toml`.
 
 ## User Overrides (Optional)
 
@@ -13,15 +13,15 @@ briefly and continue.
 ## Canonical Standards
 
 This repository follows the canonical standards and conventions in the
-`standards-and-conventions` repository.
+`vergil-tooling` repository.
 
 Resolve the local path (preferred):
 
-- `../standards-and-conventions`
+- `../vergil-tooling`
 
 If the local path is unavailable, use the canonical web source:
 
-- <https://github.com/wphillipmoore/standards-and-conventions>
+- <https://github.com/vergil-project/vergil-tooling>
 
 If the canonical standards cannot be retrieved, treat it as a fatal
 exception and stop.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,9 +3,9 @@
 This file provides guidance to Claude Code (claude.ai/code) when
 working with code in this repository.
 
-**Standards reference**: <https://github.com/wphillipmoore/standards-and-conventions>
-— active standards documentation lives in the standard-tooling repository under `docs/`.
-Repository profile: `standard-tooling.toml`.
+**Standards reference**: <https://github.com/vergil-project/vergil-tooling>
+— active standards documentation lives in the vergil-tooling repository under `docs/`.
+Repository profile: `vergil.toml`.
 
 ## Memory management
 
@@ -16,9 +16,9 @@ plugin/skill issue) before writing. See that file for the full
 workflow.
 
 Available skills:
-- `/standard-tooling:memory-init` — set up or update the policy header
+- `/vergil:memory-init` — set up or update the policy header
   in a project's `MEMORY.md`.
-- `/standard-tooling:memory-audit` — structured collaborative review
+- `/vergil:memory-audit` — structured collaborative review
   of memory files.
 
 ## Parallel AI agent development
@@ -29,9 +29,9 @@ while preserving shared project memory (which Claude Code derives from the
 session's starting CWD).
 
 **Canonical spec:**
-[`standard-tooling/docs/specs/worktree-convention.md`](https://github.com/wphillipmoore/standard-tooling/blob/develop/docs/specs/worktree-convention.md)
+[`vergil-tooling/docs/specs/worktree-convention.md`](https://github.com/vergil-project/vergil-tooling/blob/develop/docs/specs/worktree-convention.md)
 — full rationale, trust model, failure modes, and memory-path implications.
-The canonical text lives in `standard-tooling`; this section is the local
+The canonical text lives in `vergil-tooling`; this section is the local
 on-ramp.
 
 ### Structure
@@ -109,9 +109,9 @@ a real MQ queue manager.
 ### Standard Tooling
 
 ```bash
-cd ../standard-tooling && uv sync                                                # Install standard-tooling
-export PATH="../standard-tooling/.venv/bin:../standard-tooling/scripts/bin:$PATH" # Put tools on PATH
-git config core.hooksPath ../standard-tooling/scripts/lib/git-hooks               # Enable git hooks
+cd ../vergil-tooling && uv sync                                                  # Install vergil-tooling
+export PATH="../vergil-tooling/.venv/bin:../vergil-tooling/scripts/bin:$PATH"     # Put tools on PATH
+git config core.hooksPath ../vergil-tooling/scripts/lib/git-hooks                 # Enable git hooks
 ```
 
 ### Environment Setup
@@ -169,7 +169,7 @@ Consuming repositories depend on these stable details:
 
 - **Local development**: Consuming repos reference this repo as a
   sibling directory (`../mq-rest-admin-dev-environment`) — same pattern as
-  `../standards-and-conventions`
+  `../vergil-tooling`
 - **CI**: Reusable GitHub Actions workflow (or composite action) that
   starts the MQ containers, seeds them, and makes them available to
   the calling workflow's test jobs
@@ -192,7 +192,7 @@ seed/
 docs/
     plans/               # Decision documents
     repository-standards.md
-    standards-and-conventions.md
+    vergil-tooling.md
 ```
 
 ## Key References

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ against a real MQ queue manager.
 
 ## Consuming repositories
 
-- [pymqrest](https://github.com/wphillipmoore/pymqrest) — Python
+- [pymqrest](https://github.com/mq-rest-admin-project/pymqrest) — Python
   wrapper for the MQ administrative REST API
-- [mq-rest-admin](https://github.com/wphillipmoore/mq-rest-admin) —
+- [mq-rest-admin](https://github.com/mq-rest-admin-project/mq-rest-admin) —
   Java port of pymqrest
 - pymqpcf — Python wrapper for the MQ PCF API (planned)
 
@@ -124,7 +124,7 @@ jobs:
 
       - name: Setup MQ
         id: mq
-        uses: wphillipmoore/mq-rest-admin-dev-environment/.github/actions/setup-mq@main
+        uses: mq-rest-admin-project/mq-rest-admin-dev-environment/.github/actions/setup-mq@main
         with:
           verify: 'true'  # default; set 'false' to skip verification
 
@@ -192,7 +192,7 @@ config/
 docs/
   plans/                   # Decision documents
   repository-standards.md
-  standards-and-conventions.md
+  vergil-tooling.md
 scripts/
   git-hooks/               # Git hook scripts
   mq_start.sh              # Start containers + wait for readiness

--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -51,7 +51,7 @@ submission. Do not construct commit messages or PR bodies manually.
 ### Committing
 
 ```bash
-st-commit \
+vrg-commit \
   --type TYPE --message MESSAGE --agent AGENT \
   [--scope SCOPE] [--body BODY]
 ```
@@ -64,12 +64,12 @@ st-commit \
 - `--body` (optional): detailed commit body
 
 The script resolves the correct `Co-Authored-By` identity from
-`standard-tooling.toml` and the git hooks validate the result.
+`vergil.toml` and the git hooks validate the result.
 
 ### Submitting PRs
 
 ```bash
-st-submit-pr \
+vrg-submit-pr \
   --issue NUMBER --summary TEXT \
   [--linkage KEYWORD] [--title TEXT] \
   [--notes TEXT] [--docs-only] [--dry-run]

--- a/docs/site/docs/architecture/environment-contract.md
+++ b/docs/site/docs/architecture/environment-contract.md
@@ -44,8 +44,8 @@ See [CI Integration](../ci-integration.md) for usage details.
 This environment is used by the language-specific libraries in the
 mq-rest-admin project:
 
-- [mq-rest-admin-python](https://github.com/wphillipmoore/mq-rest-admin-python)
-- [mq-rest-admin-java](https://github.com/wphillipmoore/mq-rest-admin-java)
-- [mq-rest-admin-go](https://github.com/wphillipmoore/mq-rest-admin-go)
-- [mq-rest-admin-ruby](https://github.com/wphillipmoore/mq-rest-admin-ruby)
-- [mq-rest-admin-rust](https://github.com/wphillipmoore/mq-rest-admin-rust)
+- [mq-rest-admin-python](https://github.com/mq-rest-admin-project/mq-rest-admin-python)
+- [mq-rest-admin-java](https://github.com/mq-rest-admin-project/mq-rest-admin-java)
+- [mq-rest-admin-go](https://github.com/mq-rest-admin-project/mq-rest-admin-go)
+- [mq-rest-admin-ruby](https://github.com/mq-rest-admin-project/mq-rest-admin-ruby)
+- [mq-rest-admin-rust](https://github.com/mq-rest-admin-project/mq-rest-admin-rust)

--- a/docs/site/docs/ci-integration.md
+++ b/docs/site/docs/ci-integration.md
@@ -16,7 +16,7 @@ jobs:
 
       - name: Setup MQ
         id: mq
-        uses: wphillipmoore/mq-rest-admin-dev-environment/.github/actions/setup-mq@main
+        uses: mq-rest-admin-project/mq-rest-admin-dev-environment/.github/actions/setup-mq@main
         with:
           verify: 'true'
 
@@ -60,7 +60,7 @@ environments in the same workflow:
 ```yaml
 - name: Setup MQ
   id: mq
-  uses: wphillipmoore/mq-rest-admin-dev-environment/.github/actions/setup-mq@main
+  uses: mq-rest-admin-project/mq-rest-admin-dev-environment/.github/actions/setup-mq@main
   with:
     project-name: 'my-tests'
     qm1-mq-port: '11414'

--- a/docs/site/docs/index.md
+++ b/docs/site/docs/index.md
@@ -10,11 +10,11 @@ against a real MQ queue manager.
 This environment is used by the language-specific libraries in the
 mq-rest-admin project:
 
-- [mq-rest-admin-python](https://github.com/wphillipmoore/mq-rest-admin-python)
-- [mq-rest-admin-java](https://github.com/wphillipmoore/mq-rest-admin-java)
-- [mq-rest-admin-go](https://github.com/wphillipmoore/mq-rest-admin-go)
-- [mq-rest-admin-ruby](https://github.com/wphillipmoore/mq-rest-admin-ruby)
-- [mq-rest-admin-rust](https://github.com/wphillipmoore/mq-rest-admin-rust)
+- [mq-rest-admin-python](https://github.com/mq-rest-admin-project/mq-rest-admin-python)
+- [mq-rest-admin-java](https://github.com/mq-rest-admin-project/mq-rest-admin-java)
+- [mq-rest-admin-go](https://github.com/mq-rest-admin-project/mq-rest-admin-go)
+- [mq-rest-admin-ruby](https://github.com/mq-rest-admin-project/mq-rest-admin-ruby)
+- [mq-rest-admin-rust](https://github.com/mq-rest-admin-project/mq-rest-admin-rust)
 
 ## What this repo provides
 

--- a/docs/site/docs/setup/new-repo.md
+++ b/docs/site/docs/setup/new-repo.md
@@ -69,7 +69,7 @@ handles starting, seeding, and verifying the MQ environment:
 - name: Checkout MQ dev environment
   uses: actions/checkout@v4
   with:
-    repository: wphillipmoore/mq-rest-admin-dev-environment
+    repository: mq-rest-admin-project/mq-rest-admin-dev-environment
     ref: main
     path: .mq-dev-env
 

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -1,9 +1,9 @@
 site_name: mq-rest-admin-dev-environment
-site_url: https://wphillipmoore.github.io/mq-rest-admin-dev-environment/
+site_url: https://mq-rest-admin-project.github.io/mq-rest-admin-dev-environment/
 site_description: >-
   Shared dockerized IBM MQ test environment for integration testing
   across the mq-rest-admin project family
-repo_url: https://github.com/wphillipmoore/mq-rest-admin-dev-environment
+repo_url: https://github.com/mq-rest-admin-project/mq-rest-admin-dev-environment
 repo_name: mq-rest-admin-dev-environment
 edit_uri: ""
 

--- a/docs/vergil-tooling.md
+++ b/docs/vergil-tooling.md
@@ -1,7 +1,7 @@
 # Standards and Conventions
 
 This repository follows the canonical standards at:
-<https://github.com/wphillipmoore/standards-and-conventions>
+<https://github.com/vergil-project/vergil-tooling>
 
 ## Table of Contents
 
@@ -9,7 +9,7 @@ This repository follows the canonical standards at:
 - [Project-specific overlay](#project-specific-overlay)
 
 ## Canonical references
-<!-- include: ../standards-and-conventions/docs/standards-and-conventions.md -->
+<!-- include: ../vergil-tooling/docs/vergil-tooling.md -->
 
 ## Project-specific overlay
 

--- a/vergil.toml
+++ b/vergil.toml
@@ -6,8 +6,7 @@ release-model = "tagged-release"
 primary-language = "shell"
 
 [project.co-authors]
-claude = "Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@users.noreply.github.com>"
-codex = "Co-Authored-By: wphillipmoore-codex <255923655+wphillipmoore-codex@users.noreply.github.com>"
+agent = "Co-Authored-By: wphillipmoore-agent <284101533+wphillipmoore-agent@users.noreply.github.com>"
 
 [ci]
 versions = ["latest"]
@@ -18,4 +17,4 @@ release = true
 docs = true
 
 [dependencies]
-standard-tooling = "v1.4"
+vergil = "v2.0"


### PR DESCRIPTION
## Summary

- Rename `standard-tooling.toml` to `vergil.toml` and upgrade to vergil v2.0
- Update CI/CD workflows from `wphillipmoore/standard-actions@v1.5` to `vergil-project/vergil-actions@v2.0`
- Replace `secrets: inherit` with explicit secrets block in `cd.yml`
- Update all repository and documentation URLs from `wphillipmoore` to `mq-rest-admin-project` org
- Consolidate co-author entries to single `wphillipmoore-agent` identity
- Migrate Claude Code plugin config from `standard-tooling-marketplace` to `vergil-marketplace`

Ref mq-rest-admin-project/mq-rest-admin-common#195

## Test plan

- [ ] CI workflows resolve `vergil-project/vergil-actions@v2.0` successfully
- [ ] Documentation site URLs point to `mq-rest-admin-project.github.io`
- [ ] CD release job receives secrets via explicit secrets block
- [ ] No remaining `wphillipmoore` references outside `vergil.toml` co-author line

🤖 Generated with [Claude Code](https://claude.com/claude-code)