### PR TITLE
chore(ci): add missing container-tag/container-suffix and fix stale standards doc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
       language: shell
       versions: '["latest"]'
       container-suffix: base
+      container-tag: 'latest'
 
   security:
     uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v2.0
@@ -34,6 +35,8 @@ jobs:
       run-standards: ${{ inputs.run-release != 'false' }}
       run-security: ${{ inputs.run-security != 'false' }}
       run-codeql: false
+      container-suffix: base
+      container-tag: 'latest'
     permissions:
       contents: read
       security-events: write
@@ -43,3 +46,5 @@ jobs:
     with:
       language: shell
       run-release: ${{ inputs.run-release != 'false' }}
+      container-suffix: base
+      container-tag: 'latest'

--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -14,16 +14,12 @@
   for explicit approval to proceed on `develop`.
 - If approval is granted to work on `develop`, call it out in the
   response and proceed only for that user-approved scope.
-- Enable repository git hooks before committing: `git config core.hooksPath scripts/git-hooks`.
+- Enable repository git hooks before committing: `git config core.hooksPath .githooks`.
 
 ## Local validation
 
 ```bash
-# Validate the MQ environment is running and seeded correctly
-scripts/mq_verify.sh
-
-# Lint documentation
-markdownlint . --ignore node_modules
+vrg-docker-run -- vrg-validate
 ```
 
 ## Tooling requirement
@@ -32,7 +28,7 @@ Required for daily workflow:
 
 - Docker and Docker Compose (for running the MQ containers)
 - `curl` (for REST API health checks and verification)
-- `markdownlint` (required for docs validation and PR pre-submission)
+- `vrg-docker-run` (runs validation inside dev container)
 
 ## Merge strategy override
 
@@ -52,14 +48,13 @@ submission. Do not construct commit messages or PR bodies manually.
 
 ```bash
 vrg-commit \
-  --type TYPE --message MESSAGE --agent AGENT \
+  --type TYPE --message MESSAGE \
   [--scope SCOPE] [--body BODY]
 ```
 
 - `--type` (required): one of
   `feat|fix|docs|style|refactor|test|chore|ci|build`
 - `--message` (required): commit description
-- `--agent` (required): `claude` or `codex`
 - `--scope` (optional): conventional commit scope
 - `--body` (optional): detailed commit body
 
@@ -72,17 +67,16 @@ The script resolves the correct `Co-Authored-By` identity from
 vrg-submit-pr \
   --issue NUMBER --summary TEXT \
   [--linkage KEYWORD] [--title TEXT] \
-  [--notes TEXT] [--docs-only] [--dry-run]
+  [--notes TEXT] [--dry-run]
 ```
 
 - `--issue` (required): GitHub issue number (just the number)
 - `--summary` (required): one-line PR summary
-- `--linkage` (optional, default: `Fixes`):
+- `--linkage` (optional, default: `Ref`):
   `Fixes|Closes|Resolves|Ref`
 - `--title` (optional): PR title (default: most recent commit
   subject)
 - `--notes` (optional): additional notes
-- `--docs-only` (optional): applies docs-only testing exception
 - `--dry-run` (optional): print generated PR without executing
 
 The script detects the target branch and merge strategy


### PR DESCRIPTION
# Pull Request

## Summary

- Add container-tag and container-suffix to reusable workflow jobs; fix stale repository-standards.md

## Issue Linkage

- Ref vergil-project/vergil-tooling#1015

## Notes

- Also addresses vergil-project/vergil-tooling#1013. Changes: add container-tag/container-suffix to quality, security, version jobs in ci.yml; fix hooks path, validation commands, tooling requirements, remove --agent and --docs-only flags, fix --linkage default in repository-standards.md