### PR TITLE
chore(hooks): add Claude Code hook guard, scrub legacy hooksPath refs

### DIFF
--- a/.claude/hooks/guard.sh
+++ b/.claude/hooks/guard.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Claude Code PreToolUse hook shim.
+# Delegates to vrg-hook-guard if available; falls back to a
+# jq-based git/gh check that hard-denies when vergil-tooling
+# is not installed.
+set -euo pipefail
+
+if command -v vrg-hook-guard &>/dev/null; then
+  exec vrg-hook-guard
+fi
+
+input=$(cat)
+command=$(printf '%s' "$input" | jq -r '.tool_input.command // empty')
+bin=$(printf '%s' "$command" | awk '{print $1}')
+base=$(basename "$bin" 2>/dev/null || printf '%s' "$bin")
+
+case "$base" in
+  git|gh)
+    jq -n '{
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: "vergil-tooling is not available. This repository requires a correctly configured environment — all git/gh operations are blocked until resolved."
+      }
+    }'
+    exit 0
+    ;;
+esac
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,22 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(vrg-*)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/guard.sh"
+          }
+        ]
+      }
+    ]
+  },
   "extraKnownMarketplaces": {
     "vergil-marketplace": {
       "source": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,11 +108,9 @@ a real MQ queue manager.
 
 ### Standard Tooling
 
-```bash
-cd ../vergil-tooling && uv sync                                                  # Install vergil-tooling
-export PATH="../vergil-tooling/.venv/bin:../vergil-tooling/scripts/bin:$PATH"     # Put tools on PATH
-git config core.hooksPath ../vergil-tooling/scripts/lib/git-hooks                 # Enable git hooks
-```
+The Claude Code PreToolUse hook guard (`.claude/hooks/guard.sh`)
+blocks raw `git` and `gh` commands — use `vrg-git` / `vrg-gh`
+wrappers.
 
 ### Environment Setup
 

--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -14,7 +14,7 @@
   for explicit approval to proceed on `develop`.
 - If approval is granted to work on `develop`, call it out in the
   response and proceed only for that user-approved scope.
-- Enable repository git hooks before committing: `git config core.hooksPath .githooks`.
+- The Claude Code hook guard (`.claude/hooks/guard.sh`) blocks raw `git`/`gh` — use `vrg-git`/`vrg-gh`.
 
 ## Local validation
 


### PR DESCRIPTION
# Pull Request

## Summary

- Add PreToolUse hook guard, update settings.json, scrub legacy core.hooksPath references from docs

## Issue Linkage

- Ref #140

## Notes

- Part of vergil-project/vergil-tooling#1142