### PR TITLE
chore(tooling): migrate to vergil v2.1

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,7 +21,8 @@
     "vergil-marketplace": {
       "source": {
         "source": "github",
-        "repo": "vergil-project/vergil-claude-plugin"
+        "repo": "vergil-project/vergil-claude-plugin",
+        "ref": "v2.1"
       }
     }
   },

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   docs:
-    uses: vergil-project/vergil-actions/.github/workflows/cd-docs.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/cd-docs.yml@v2.1
     with:
       pre-deploy-command: >-
         git clone --depth 1 --branch develop
@@ -25,5 +25,5 @@ jobs:
 
   release:
     if: github.ref == 'refs/heads/main'
-    uses: vergil-project/vergil-actions/.github/workflows/cd-release.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/cd-release.yml@v2.1
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -21,7 +22,7 @@ concurrency:
 
 jobs:
   quality:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-quality.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/ci-quality.yml@v2.1
     with:
       language: shell
       versions: '["latest"]'
@@ -29,7 +30,7 @@ jobs:
       container-tag: 'latest'
 
   security:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v2.1
     with:
       language: shell
       run-standards: ${{ inputs.run-release != 'false' }}
@@ -40,9 +41,10 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      actions: read
 
   version:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-version-bump.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/ci-version-bump.yml@v2.1
     with:
       language: shell
       run-release: ${{ inputs.run-release != 'false' }}

--- a/vergil.toml
+++ b/vergil.toml
@@ -13,4 +13,4 @@ release = true
 docs = true
 
 [dependencies]
-vergil = "v2.0"
+vergil = "v2.1"


### PR DESCRIPTION
# Pull Request

## Summary

- Migrate mq-rest-admin-dev-environment from vergil v2.0 to v2.1 across dep, workflow refs, and marketplace ref.

## Issue Linkage

- Ref #145

## Notes

- Scope: vergil.toml dep, 5 vergil-actions refs (ci.yml x3, cd.yml x2), .claude/settings.json marketplace ref (added; previously absent). actions: read granted to ci.yml top-level and security job per v2.1 ci-security.yml (vergil-actions#693/#698). Version divergence: VERSION 1.2.3 vs latest tag v1.2.2 (pending unreleased bump, not edited).