### PR TITLE
fix(compose): pin MQ image to 9.4.5.1-r1 (latest supported 9.x)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,7 +159,7 @@ Consuming repositories depend on these stable details:
 | QM2 MQ listener | `localhost:1415` |
 | Admin user | `mqadmin` / `mqadmin` |
 | Reader user | `mqreader` / `mqreader` |
-| Docker image | `icr.io/ibm-messaging/mq:latest` (IBM MQ for Developers) |
+| Docker image | `icr.io/ibm-messaging/mq:9.4.5.1-r1` (IBM MQ for Developers) |
 | Docker network | `mq-dev-net` |
 
 ### Seed Data Strategy

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Consuming repositories depend on these stable details:
 | QM2 MQ listener | `localhost:1415` |
 | Admin user | `mqadmin` / `mqadmin` |
 | Reader user | `mqreader` / `mqreader` |
-| Docker image | `icr.io/ibm-messaging/mq:latest` |
+| Docker image | `icr.io/ibm-messaging/mq:9.4.5.1-r1` |
 | Docker network | `mq-dev-net` |
 
 ## Seed objects

--- a/config/docker-compose.yml
+++ b/config/docker-compose.yml
@@ -3,7 +3,7 @@ networks:
 
 services:
   qm1:
-    image: ${MQ_IMAGE:-icr.io/ibm-messaging/mq:latest}
+    image: ${MQ_IMAGE:-icr.io/ibm-messaging/mq:9.4.5.1-r1}
     hostname: qm1
     networks:
       - mq-dev-net
@@ -26,7 +26,7 @@ services:
       retries: 12
 
   qm2:
-    image: ${MQ_IMAGE:-icr.io/ibm-messaging/mq:latest}
+    image: ${MQ_IMAGE:-icr.io/ibm-messaging/mq:9.4.5.1-r1}
     hostname: qm2
     networks:
       - mq-dev-net

--- a/docs/site/docs/architecture/environment-contract.md
+++ b/docs/site/docs/architecture/environment-contract.md
@@ -16,7 +16,7 @@ coordination with all language libraries.
 | QM2 MQ listener | `localhost:1415` |
 | Admin user | `mqadmin` / `mqadmin` |
 | Reader user | `mqreader` / `mqreader` |
-| Docker image | `icr.io/ibm-messaging/mq:latest` |
+| Docker image | `icr.io/ibm-messaging/mq:9.4.5.1-r1` |
 | Docker network | `mq-dev-net` |
 
 ## Seed objects

--- a/docs/site/docs/configuration/docker-compose.md
+++ b/docs/site/docs/configuration/docker-compose.md
@@ -9,7 +9,7 @@ and defines two IBM MQ container services with REST API access.
 
 | Property | Value |
 | --- | --- |
-| Image | `icr.io/ibm-messaging/mq:latest` |
+| Image | `icr.io/ibm-messaging/mq:9.4.5.1-r1` |
 | Hostname | `qm1` |
 | MQ listener port | `1414` (host: `1414`) |
 | REST API port | `9443` (host: `9443`) |
@@ -19,7 +19,7 @@ and defines two IBM MQ container services with REST API access.
 
 | Property | Value |
 | --- | --- |
-| Image | `icr.io/ibm-messaging/mq:latest` |
+| Image | `icr.io/ibm-messaging/mq:9.4.5.1-r1` |
 | Hostname | `qm2` |
 | MQ listener port | `1414` (host: `1415`) |
 | REST API port | `9443` (host: `9444`) |
@@ -32,7 +32,7 @@ overrides:
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `MQ_IMAGE` | `icr.io/ibm-messaging/mq:latest` | Container image |
+| `MQ_IMAGE` | `icr.io/ibm-messaging/mq:9.4.5.1-r1` | Container image |
 | `QM1_MQ_PORT` | `1414` | Host port for QM1 MQ listener |
 | `QM1_REST_PORT` | `9443` | Host port for QM1 REST API |
 | `QM2_MQ_PORT` | `1415` | Host port for QM2 MQ listener |

--- a/docs/site/docs/reference/environment-variables.md
+++ b/docs/site/docs/reference/environment-variables.md
@@ -10,7 +10,7 @@ before running `mq_start.sh` to override defaults.
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `MQ_IMAGE` | `icr.io/ibm-messaging/mq:latest` | IBM MQ container image |
+| `MQ_IMAGE` | `icr.io/ibm-messaging/mq:9.4.5.1-r1` | IBM MQ container image |
 | `QM1_MQ_PORT` | `1414` | Host port for QM1 MQ listener |
 | `QM1_REST_PORT` | `9443` | Host port for QM1 REST API |
 | `QM2_MQ_PORT` | `1415` | Host port for QM2 MQ listener |


### PR DESCRIPTION
# Pull Request

## Summary

- Pin the dev-environment MQ image off the floating :latest tag (which rolled to unsupported MQ 10.0.0 and broke fleet integration CI) to the latest 9.x, 9.4.5.1-r1, and sync the current-state docs.

## Issue Linkage

- Ref #147

## Notes

- Root cause: :latest -> MQ 10.0.0, whose new quantum-safe CHSTATUS attrs (SSLQS/SSLQSR) are unmapped, tripping strict response mapping in every language client (integration gate only; unit/quality/security/audit all green). Tag verified against icr.io registry (latest 9.x = 9.4.5.1-r1; only 10.x = 10.0.0.0-r1). MQ_IMAGE override preserved. PROPAGATION: language repos consume setup-mq@main and the compose default (nothing sets MQ_IMAGE), so this fixes the whole fleet's integration CI once it reaches the dev-environment main branch via the develop->main release. v10 enablement tracked in mq-rest-admin-common#217; this issue is the 9.x pin only.