### PR TITLE
fix(scripts): gate lifecycle on queue-manager stability window

### DIFF
--- a/.github/actions/setup-mq/action.yml
+++ b/.github/actions/setup-mq/action.yml
@@ -56,6 +56,8 @@ runs:
       working-directory: ${{ github.action_path }}/../../..
       env:
         COMPOSE_PROJECT_NAME: ${{ inputs.project-name }}
+        QM1_REST_PORT: ${{ inputs.qm1-rest-port }}
+        QM2_REST_PORT: ${{ inputs.qm2-rest-port }}
       run: scripts/mq_seed.sh
 
     - name: Verify MQ environment

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,6 +185,7 @@ Consuming repositories depend on these stable details:
 ```text
 scripts/
     mq_start.sh          # Start containers + wait for readiness
+    mq_wait_ready.sh     # Shared readiness gate (stability window)
     mq_seed.sh           # Run MQSC seed scripts
     mq_verify.sh         # Verify seed objects via REST API
     mq_reset.sh          # Full reset (stop + start + seed)

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ docs/
 scripts/
   git-hooks/               # Git hook scripts
   mq_start.sh              # Start containers + wait for readiness
+  mq_wait_ready.sh         # Shared readiness gate (stability window)
   mq_seed.sh               # Run MQSC seed scripts
   mq_verify.sh             # Verify seed objects via REST API
   mq_reset.sh              # Full reset (stop + remove volumes)

--- a/docs/site/docs/lifecycle-scripts.md
+++ b/docs/site/docs/lifecycle-scripts.md
@@ -18,8 +18,32 @@ scripts/mq_start.sh
 The script:
 
 1. Runs `docker compose up -d` using `config/docker-compose.yml`
-2. Waits for container health checks to pass
-3. Polls the REST API endpoints until they respond
+2. Delegates to `mq_wait_ready.sh` to block until both REST APIs serve
+   requests reliably
+
+### mq_wait_ready.sh
+
+Readiness gate shared by `mq_start.sh`, `mq_seed.sh`, and `mq_verify.sh`.
+Polls both queue managers' administrative REST endpoints and only
+returns once **every** queue manager has answered healthily for several
+consecutive rounds (a stability window).
+
+```bash
+scripts/mq_wait_ready.sh
+```
+
+A single successful probe is not enough: during startup the MQ web
+server answers one request while the queue manager is still
+stabilising, then resets connections moments later (seen downstream as
+`SSL_ERROR_SYSCALL` / `Connection reset by peer`). Requiring a stability
+window keeps seed/verify and the consuming repos' tests from racing
+startup. On timeout the script exits non-zero with an explicit
+"queue manager not ready after N seconds" message so a genuine startup
+failure is distinguishable from a slow start.
+
+Tunable via [environment variables](reference/environment-variables.md#readiness-gate-variables)
+(`MQ_READY_TIMEOUT_SECONDS`, `MQ_READY_INTERVAL_SECONDS`,
+`MQ_READY_CONSECUTIVE`).
 
 ### mq_seed.sh
 
@@ -32,10 +56,11 @@ scripts/mq_seed.sh
 
 The script:
 
-1. Copies `seed/base-qm1.mqsc` into the QM1 container
-2. Runs `runmqsc QM1` with the seed file
-3. Copies `seed/base-qm2.mqsc` into the QM2 container
-4. Runs `runmqsc QM2` with the seed file
+1. Blocks on `mq_wait_ready.sh` so seeding never races startup
+2. Copies `seed/base-qm1.mqsc` into the QM1 container
+3. Runs `runmqsc QM1` with the seed file
+4. Copies `seed/base-qm2.mqsc` into the QM2 container
+5. Runs `runmqsc QM2` with the seed file
 
 ### mq_verify.sh
 
@@ -46,8 +71,9 @@ API on both queue managers.
 scripts/mq_verify.sh
 ```
 
-The script checks each object type (queues, channels, topics, etc.)
-and reports success or failure for each.
+The script first blocks on `mq_wait_ready.sh`, then checks each object
+type (queues, channels, topics, etc.) and reports success or failure
+for each.
 
 ### mq_reset.sh
 

--- a/docs/site/docs/reference/environment-variables.md
+++ b/docs/site/docs/reference/environment-variables.md
@@ -39,6 +39,17 @@ Used by the lifecycle scripts and seed/verify operations.
 | `MQ_ADMIN_USER` | `mqadmin` | Admin username for REST API authentication |
 | `MQ_ADMIN_PASSWORD` | `mqadmin` | Admin password for REST API authentication |
 
+## Readiness gate variables
+
+Used by `mq_wait_ready.sh` (called from `mq_start.sh`, `mq_seed.sh`, and
+`mq_verify.sh`) to tune the startup stability window.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `MQ_READY_TIMEOUT_SECONDS` | `120` | Hard timeout before the gate fails with an explicit "not ready" error |
+| `MQ_READY_INTERVAL_SECONDS` | `3` | Seconds between readiness probe rounds |
+| `MQ_READY_CONSECUTIVE` | `3` | Consecutive healthy rounds (across both queue managers) required before proceeding |
+
 ## Test gate variables
 
 Control integration test execution in consuming repositories.

--- a/scripts/mq_seed.sh
+++ b/scripts/mq_seed.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Don't seed until both queue managers serve requests — seeding (and
+# the verify/tests that follow) must not race container startup.
+scripts/mq_wait_ready.sh
+
 # runmqsc returns the count of failed commands as its exit code.
 # START CHANNEL fails harmlessly when the channel is already running,
 # so tolerate non-zero exits here.  Output is still printed for

--- a/scripts/mq_start.sh
+++ b/scripts/mq_start.sh
@@ -3,44 +3,7 @@ set -euo pipefail
 
 docker compose -f config/docker-compose.yml up -d
 
-mq_admin_user="${MQ_ADMIN_USER:-mqadmin}"
-mq_admin_password="${MQ_ADMIN_PASSWORD:-mqadmin}"
-wait_timeout_seconds=120
-wait_interval_seconds=5
-
-qm1_rest_port="${QM1_REST_PORT:-9443}"
-qm2_rest_port="${QM2_REST_PORT:-9444}"
-
-wait_for_qm() {
-  local rest_base_url="$1"
-  local qmgr_name="$2"
-  local start_epoch
-  start_epoch="$(date +%s)"
-
-  while true; do
-    if curl -sS -k -u "${mq_admin_user}:${mq_admin_password}" \
-      -H "Content-Type: application/json" \
-      -H "ibm-mq-rest-csrf-token: local" \
-      -d '{"type": "runCommandJSON", "command": "DISPLAY", "qualifier": "QMGR"}' \
-      -o /dev/null \
-      --fail \
-      --max-time 5 \
-      "${rest_base_url}/admin/action/qmgr/${qmgr_name}/mqsc"; then
-      echo "${qmgr_name} REST endpoint is ready."
-      return 0
-    fi
-
-    now_epoch="$(date +%s)"
-    elapsed_seconds="$((now_epoch - start_epoch))"
-    if ((elapsed_seconds >= wait_timeout_seconds)); then
-      echo "Timed out waiting for ${qmgr_name} REST endpoint after ${wait_timeout_seconds}s." >&2
-      return 1
-    fi
-
-    echo "Waiting for ${qmgr_name} REST endpoint (${elapsed_seconds}s elapsed)..."
-    sleep "${wait_interval_seconds}"
-  done
-}
-
-wait_for_qm "https://localhost:${qm1_rest_port}/ibmmq/rest/v2" "QM1"
-wait_for_qm "https://localhost:${qm2_rest_port}/ibmmq/rest/v2" "QM2"
+# Block until both queue managers serve requests reliably.  The
+# readiness gate lives in mq_wait_ready.sh so seed/verify (and any
+# standalone caller) inherit the same stability window.
+scripts/mq_wait_ready.sh

--- a/scripts/mq_verify.sh
+++ b/scripts/mq_verify.sh
@@ -9,6 +9,9 @@ qm2_rest_port="${QM2_REST_PORT:-9444}"
 qm1_rest_base_url="https://localhost:${qm1_rest_port}/ibmmq/rest/v2"
 qm2_rest_base_url="https://localhost:${qm2_rest_port}/ibmmq/rest/v2"
 
+# Don't probe seed objects until both queue managers serve requests.
+scripts/mq_wait_ready.sh
+
 echo "=== QM1: DEV.QLOCAL ==="
 curl -sS -k -u "${mq_admin_user}:${mq_admin_password}" \
   -H "Content-Type: application/json" \

--- a/scripts/mq_wait_ready.sh
+++ b/scripts/mq_wait_ready.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Readiness gate for the MQ dev environment.
+#
+# Polls each queue manager's administrative REST endpoint and only
+# returns success once EVERY queue manager has answered healthily for
+# MQ_READY_CONSECUTIVE consecutive rounds.
+#
+# A single successful probe is not enough: during startup the MQ web
+# server accepts a connection and answers one request while the queue
+# manager is still stabilising, then resets connections moments later
+# (observed downstream as `SSL_ERROR_SYSCALL` / `Connection reset by
+# peer`).  Requiring a stability window keeps seed/verify and the
+# consuming repos' tests from firing into that window.
+#
+# On timeout the script exits non-zero with an explicit message so a
+# genuine startup failure is distinguishable from a slow start.
+
+mq_admin_user="${MQ_ADMIN_USER:-mqadmin}"
+mq_admin_password="${MQ_ADMIN_PASSWORD:-mqadmin}"
+
+qm1_rest_port="${QM1_REST_PORT:-9443}"
+qm2_rest_port="${QM2_REST_PORT:-9444}"
+
+wait_timeout_seconds="${MQ_READY_TIMEOUT_SECONDS:-120}"
+wait_interval_seconds="${MQ_READY_INTERVAL_SECONDS:-3}"
+required_consecutive="${MQ_READY_CONSECUTIVE:-3}"
+
+# Parallel arrays: queue manager name -> REST base URL.
+qmgr_names=("QM1" "QM2")
+rest_base_urls=(
+  "https://localhost:${qm1_rest_port}/ibmmq/rest/v2"
+  "https://localhost:${qm2_rest_port}/ibmmq/rest/v2"
+)
+
+probe_qm() {
+  local rest_base_url="$1"
+  local qmgr_name="$2"
+  curl -sS -k -u "${mq_admin_user}:${mq_admin_password}" \
+    -H "Content-Type: application/json" \
+    -H "ibm-mq-rest-csrf-token: local" \
+    -d '{"type": "runCommandJSON", "command": "DISPLAY", "qualifier": "QMGR"}' \
+    -o /dev/null \
+    --fail \
+    --retry 2 \
+    --retry-connrefused \
+    --max-time 5 \
+    "${rest_base_url}/admin/action/qmgr/${qmgr_name}/mqsc"
+}
+
+all_qms_ready() {
+  local i
+  for i in "${!qmgr_names[@]}"; do
+    if ! probe_qm "${rest_base_urls[$i]}" "${qmgr_names[$i]}"; then
+      return 1
+    fi
+  done
+  return 0
+}
+
+start_epoch="$(date +%s)"
+consecutive=0
+
+while true; do
+  if all_qms_ready; then
+    consecutive=$((consecutive + 1))
+    if ((consecutive >= required_consecutive)); then
+      echo "All queue managers ready (${required_consecutive} consecutive healthy probes)."
+      exit 0
+    fi
+    echo "Queue managers healthy (${consecutive}/${required_consecutive} consecutive)..."
+  else
+    if ((consecutive > 0)); then
+      echo "Readiness probe regressed before reaching ${required_consecutive} consecutive; resetting stability counter."
+    fi
+    consecutive=0
+  fi
+
+  now_epoch="$(date +%s)"
+  elapsed_seconds="$((now_epoch - start_epoch))"
+  if ((elapsed_seconds >= wait_timeout_seconds)); then
+    echo "Queue manager not ready after ${wait_timeout_seconds}s" \
+      "(needed ${required_consecutive} consecutive healthy probes, reached ${consecutive})." >&2
+    exit 1
+  fi
+
+  sleep "${wait_interval_seconds}"
+done


### PR DESCRIPTION
# Pull Request

## Summary

- Replace mq_start.sh's single-probe readiness wait with a shared mq_wait_ready.sh gate that requires N consecutive healthy REST probes across both queue managers, fixing the integration-suite flake where tests fired into a still-stabilising queue manager.

## Issue Linkage

- Ref #152

## Notes

- Root cause: the old wait returned after one successful probe; the MQ web server answers one request mid-startup then resets connections (SSL_ERROR_SYSCALL / Connection reset by peer), surfacing in consuming repos' tests after setup-mq went green. New gate adds a stability window (MQ_READY_CONSECUTIVE, default 3), curl retry hardening, and an explicit timeout message. mq_start.sh, mq_seed.sh, and mq_verify.sh all gate through it; the setup-mq Seed step now passes QM REST ports so the gate probes correctly. Docs (lifecycle-scripts, environment-variables, README, CLAUDE.md) updated. vrg-validate green.