### PR TITLE
feat(env): multi-version MQ testing via mq-versions.json manifest

### DIFF
--- a/.github/actions/setup-mq/action.yml
+++ b/.github/actions/setup-mq/action.yml
@@ -4,6 +4,10 @@ description: >-
   and verify the environment is ready.
 
 inputs:
+  mq-version:
+    description: "MQ version alias from mq-versions.json (default: manifest default)"
+    required: false
+    default: ''
   project-name:
     description: COMPOSE_PROJECT_NAME for container isolation
     required: false
@@ -30,6 +34,15 @@ inputs:
     default: 'true'
 
 outputs:
+  mq-version:
+    description: Resolved MQ version alias
+    value: ${{ steps.resolve.outputs.mq-version }}
+  mq-image:
+    description: Resolved MQ container image tag
+    value: ${{ steps.resolve.outputs.mq-image }}
+  mq-caps:
+    description: Capability tokens for the resolved version (JSON array)
+    value: ${{ steps.resolve.outputs.mq-caps }}
   qm1-rest-url:
     description: QM1 REST API base URL
     value: https://localhost:${{ inputs.qm1-rest-port }}/ibmmq/rest/v2
@@ -40,11 +53,29 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Resolve MQ version
+      id: resolve
+      shell: bash
+      working-directory: ${{ github.action_path }}/../../..
+      env:
+        MQ_VERSION: ${{ inputs.mq-version }}
+        MQ_PROJECT_NAME_PREFIX: ${{ inputs.project-name }}
+      run: |
+        # shellcheck source=scripts/mq_resolve_version.sh
+        source scripts/mq_resolve_version.sh
+        mq_resolve "${MQ_VERSION:-}"
+        {
+          echo "mq-version=$MQ_VERSION"
+          echo "mq-image=$MQ_IMAGE"
+          echo "mq-caps=$MQ_CAPS"
+        } >> "$GITHUB_OUTPUT"
+
     - name: Start MQ containers
       shell: bash
       working-directory: ${{ github.action_path }}/../../..
       env:
-        COMPOSE_PROJECT_NAME: ${{ inputs.project-name }}
+        MQ_VERSION: ${{ inputs.mq-version }}
+        MQ_PROJECT_NAME_PREFIX: ${{ inputs.project-name }}
         QM1_REST_PORT: ${{ inputs.qm1-rest-port }}
         QM2_REST_PORT: ${{ inputs.qm2-rest-port }}
         QM1_MQ_PORT: ${{ inputs.qm1-mq-port }}
@@ -55,7 +86,8 @@ runs:
       shell: bash
       working-directory: ${{ github.action_path }}/../../..
       env:
-        COMPOSE_PROJECT_NAME: ${{ inputs.project-name }}
+        MQ_VERSION: ${{ inputs.mq-version }}
+        MQ_PROJECT_NAME_PREFIX: ${{ inputs.project-name }}
         QM1_REST_PORT: ${{ inputs.qm1-rest-port }}
         QM2_REST_PORT: ${{ inputs.qm2-rest-port }}
       run: scripts/mq_seed.sh
@@ -65,7 +97,8 @@ runs:
       shell: bash
       working-directory: ${{ github.action_path }}/../../..
       env:
-        COMPOSE_PROJECT_NAME: ${{ inputs.project-name }}
+        MQ_VERSION: ${{ inputs.mq-version }}
+        MQ_PROJECT_NAME_PREFIX: ${{ inputs.project-name }}
         QM1_REST_PORT: ${{ inputs.qm1-rest-port }}
         QM2_REST_PORT: ${{ inputs.qm2-rest-port }}
       run: scripts/mq_verify.sh

--- a/.github/workflows/mq-versions.yml
+++ b/.github/workflows/mq-versions.yml
@@ -1,0 +1,34 @@
+name: MQ versions
+# Reusable workflow: publishes the supported MQ version list (from
+# mq-versions.json) so consuming repos can build a test matrix that
+# stays in sync with this repo. Consume at the rolling vX.Y tag.
+
+on:
+  workflow_call:
+    outputs:
+      versions:
+        description: JSON array of supported MQ version aliases
+        value: ${{ jobs.versions.outputs.versions }}
+      default:
+        description: Default MQ version alias
+        value: ${{ jobs.versions.outputs.default }}
+
+permissions:
+  contents: read
+
+jobs:
+  versions:
+    runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.read.outputs.versions }}
+      default: ${{ steps.read.outputs.default }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Read manifest
+        id: read
+        shell: bash
+        run: |
+          {
+            echo "versions=$(bash scripts/mq_versions_matrix.sh)"
+            echo "default=$(jq -r '.default' mq-versions.json)"
+          } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/shell-tests.yml
+++ b/.github/workflows/shell-tests.yml
@@ -1,0 +1,23 @@
+name: Shell tests
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run bash tests
+        shell: bash
+        run: |
+          status=0
+          for t in tests/*.sh; do
+            echo "== $t =="
+            bash "$t" || status=1
+          done
+          exit "$status"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,8 @@ a real MQ queue manager.
 - **Docker**: Docker Desktop or equivalent with Docker Compose v2
 - **curl**: For REST API health checks (typically pre-installed on
   macOS/Linux)
+- **jq**: JSON processor used to read `mq-versions.json` for version
+  selection (`brew install jq` / `apt-get install jq`)
 
 ### Container Lifecycle
 
@@ -141,6 +143,15 @@ scripts/mq_seed.sh           # Run MQSC seed commands on both queue managers
 scripts/mq_verify.sh         # Verify seed objects exist via REST API
 scripts/mq_reset.sh          # Stop + start + re-seed (full reset)
 scripts/mq_stop.sh           # Stop and remove containers
+```
+
+Select the MQ version with `MQ_VERSION` (alias from `mq-versions.json`;
+defaults to the manifest `default`). Each version uses its own Docker
+volumes, so switching is non-destructive:
+
+```bash
+MQ_VERSION=10.0 scripts/mq_start.sh    # run 10.0
+MQ_VERSION=9.4.5 scripts/mq_start.sh   # run 9.4.5
 ```
 
 ## Architecture
@@ -159,7 +170,7 @@ Consuming repositories depend on these stable details:
 | QM2 MQ listener | `localhost:1415` |
 | Admin user | `mqadmin` / `mqadmin` |
 | Reader user | `mqreader` / `mqreader` |
-| Docker image | `icr.io/ibm-messaging/mq:9.4.5.1-r1` (IBM MQ for Developers) |
+| Docker image | Selected via `mq-versions.json` (`MQ_VERSION`); default `icr.io/ibm-messaging/mq:9.4.5.1-r1` |
 | Docker network | `mq-dev-net` |
 
 ### Seed Data Strategy

--- a/README.md
+++ b/README.md
@@ -107,6 +107,14 @@ queue manager to route MQSC commands to the other.
 | `scripts/mq_reset.sh` | Stop containers, remove volumes, and restart cleanly |
 | `scripts/mq_stop.sh` | Stop and remove containers (preserves volumes) |
 
+### MQ version selection
+
+`mq-versions.json` lists the supported MQ versions. Set `MQ_VERSION` to an
+alias (e.g. `10.0`, `9.4.5`) for any lifecycle script; omit it to use the
+manifest `default`. CI consumers call the reusable `mq-versions.yml`
+workflow to build a matrix and pass `mq-version` to the `setup-mq` action;
+track the rolling `vX.Y` tag so new versions are picked up automatically.
+
 ## CI integration
 
 This repository provides a composite action at

--- a/README.md
+++ b/README.md
@@ -111,9 +111,11 @@ queue manager to route MQSC commands to the other.
 
 `mq-versions.json` lists the supported MQ versions. Set `MQ_VERSION` to an
 alias (e.g. `10.0`, `9.4.5`) for any lifecycle script; omit it to use the
-manifest `default`. CI consumers call the reusable `mq-versions.yml`
-workflow to build a matrix and pass `mq-version` to the `setup-mq` action;
-track the rolling `vX.Y` tag so new versions are picked up automatically.
+manifest `default`. An unrecognized `MQ_VERSION` fails loudly, printing the
+list of valid aliases — there is no silent fallback. CI consumers call the
+reusable `mq-versions.yml` workflow to build a matrix and pass `mq-version`
+to the `setup-mq` action; track the rolling `vX.Y` tag so new versions are
+picked up automatically.
 
 ## CI integration
 
@@ -141,18 +143,64 @@ jobs:
       # ${{ steps.mq.outputs.qm2-rest-url }}
 ```
 
+### Multi-version matrix
+
+Call the reusable `mq-versions.yml` workflow to discover supported versions,
+then build a matrix from its output and pass the resolved alias to
+`setup-mq`:
+
+```yaml
+jobs:
+  mq-versions:
+    uses: mq-rest-admin-project/mq-rest-admin-dev-environment/.github/workflows/mq-versions.yml@v1.2
+    # outputs: versions (JSON array), default
+
+  test:
+    needs: mq-versions
+    strategy:
+      matrix:
+        mq: ${{ fromJSON(needs.mq-versions.outputs.versions) }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup MQ (${{ matrix.mq }})
+        id: mq
+        uses: mq-rest-admin-project/mq-rest-admin-dev-environment/.github/actions/setup-mq@v1.2
+        with:
+          mq-version: ${{ matrix.mq }}
+
+      # ${{ steps.mq.outputs.mq-version }}  — resolved alias
+      # ${{ steps.mq.outputs.mq-image }}    — container image tag
+      # ${{ steps.mq.outputs.mq-caps }}     — capability tokens (JSON array)
+      # ${{ steps.mq.outputs.qm1-rest-url }}
+      # ${{ steps.mq.outputs.qm2-rest-url }}
+```
+
+Track the rolling `vX.Y` tag (e.g. `v1.2`) so new MQ versions are picked up
+without workflow changes.
+
 ### Inputs
 
 | Input | Required | Default | Description |
 | --- | --- | --- | --- |
+| `mq-version` | No | `''` | MQ version alias from `mq-versions.json` (default: manifest default) |
+| `project-name` | No | `'mq-dev'` | `COMPOSE_PROJECT_NAME` for container isolation |
+| `qm1-rest-port` | No | `'9443'` | Host port for QM1 REST API |
+| `qm2-rest-port` | No | `'9444'` | Host port for QM2 REST API |
+| `qm1-mq-port` | No | `'1414'` | Host port for QM1 MQ listener |
+| `qm2-mq-port` | No | `'1415'` | Host port for QM2 MQ listener |
 | `verify` | No | `'true'` | Run `mq_verify.sh` after seeding |
 
 ### Outputs
 
-| Output | Value |
+| Output | Description |
 | --- | --- |
-| `qm1-rest-url` | `https://localhost:9443/ibmmq/rest/v2` |
-| `qm2-rest-url` | `https://localhost:9444/ibmmq/rest/v2` |
+| `mq-version` | Resolved MQ version alias |
+| `mq-image` | Resolved MQ container image tag |
+| `mq-caps` | Capability tokens for the resolved version (JSON array) |
+| `qm1-rest-url` | QM1 REST API base URL |
+| `qm2-rest-url` | QM2 REST API base URL |
 
 ## Local development
 

--- a/docs/plans/2026-06-23-multi-version-mq-testing-design.md
+++ b/docs/plans/2026-06-23-multi-version-mq-testing-design.md
@@ -16,8 +16,20 @@ independently as they ship — without consuming repos hardcoding or
 drifting on the version set.
 
 A secondary driver is a backward-compatibility question: is 10.0 a
-drop-in for the administrative REST API? The mechanism below makes that
-question answerable by running the same suite against both versions.
+drop-in for the administrative REST API? This is **not hypothetical**.
+The image previously floated on `…/mq:latest`, which rolled to MQ 10.0.0;
+real 10.0 returned new quantum-safe `DISPLAY CHSTATUS` attributes
+(`SSLQS`/`SSLQSR`) that the shared `mapping-data.json` did not map, so
+every language repo's strict response mapper raised and the integration
+CI gate failed. Commit `12717c1` (#148, 2026-06-23) pinned the image to
+`9.4.5.1-r1` to escape that, and v10 enablement — including the
+`SSLQS`/`SSLQSR` mappings — is tracked in `mq-rest-admin-common#217`.
+
+So this work is not "discover whether 10.0 breaks the mapper." We
+already know it does, in a specific way, today. This mechanism makes 10.0
+a first-class, selectable test target so that fix (and future ones) can
+be validated against both versions — and it must be sequenced behind the
+mapping work, not ahead of it.
 
 ## Decisions (resolved during brainstorming)
 
@@ -27,12 +39,19 @@ question answerable by running the same suite against both versions.
    with a matrix that runs the whole suite once per version. No
    side-by-side topology.
 2. **Source of truth: a manifest in this repo.** A single
-   `mq-versions.yml` maps version aliases to image tags and capability
-   tokens and names a `default`. Scripts, the action, and a reusable
-   workflow all read it. Adding/retiring a version is a one-line edit
-   here.
-3. **Default version: `10.0`.** When no version is selected, the
-   environment uses the manifest `default`, which is `10.0`.
+   `mq-versions.json` maps version aliases to image tags and capability
+   tokens and names a `default`. JSON (not YAML) so bash scripts parse it
+   with `jq` — one common dependency — and so the version list drops
+   straight into a GitHub Actions matrix via `fromJSON` with no
+   conversion. Scripts, the action, and a reusable workflow all read it.
+   Adding/retiring a version is a one-line edit here.
+3. **Default version: `10.0` is the end-state, gated on the mapper.**
+   When no version is selected, the environment uses the manifest
+   `default`. `10.0` is the intended default, but flipping it is what
+   makes every default-only consumer start exercising 10.0, so it is
+   sequenced behind the `mq-rest-admin-common#217` mapper fix (see
+   Dependencies & sequencing). The manifest may ship with
+   `default: "9.4.5"` until then.
 4. **Version-aware tests: yes.** The environment exports the resolved
    version and a capability map so consuming-repo tests can assert
    version-specific behavior or skip where a capability is absent,
@@ -45,11 +64,11 @@ environment contract stays invariant across versions because only one
 version runs at a time on the same ports.
 
 ```text
-mq-versions.yml  (source of truth)
+mq-versions.json  (source of truth, parsed with jq)
    |
    +-- scripts/        mq_resolve_version.sh -> MQ_IMAGE/MQ_VERSION/MQ_CAPS  (local dev)
    +-- setup-mq action mq-version input  -> resolved version/image/caps outputs (CI per matrix leg)
-   +-- mq-versions.yml workflow  emits version list as matrix JSON (CI matrix source)
+   +-- mq-versions workflow  emits version list as matrix JSON (CI matrix source)
 ```
 
 **Contract invariant.** Because exactly one version runs at a time on
@@ -58,38 +77,71 @@ documented in `CLAUDE.md` and `README.md` is byte-for-byte identical
 across versions. Consumers point at the same REST URLs regardless of
 version; the only thing that varies is an out-of-band version *signal*.
 
+**Boundary with the shared mapper.** The thing that actually broke on
+10.0 is not in this repo: it is the strict response mapper driven by
+`mapping-data.json`, which lives in `mq-rest-admin-common` and is shared
+by all the language repos. This repo owns *which MQ version is running
+and how to select it*; `mq-rest-admin-common` owns *how REST responses
+from that version are mapped to fields*. The two must not both try to
+own the attribute catalog (see Dependencies & sequencing). This repo's
+version signal is the input that lets the mapper — and version-aware
+tests — branch correctly; it is not itself the attribute map.
+
 ## Component 1 — the version manifest
 
-New file `mq-versions.yml` (repo root):
+New file `mq-versions.json` (repo root). JSON comments are not legal, so
+the gating note lives in the spec/docs rather than the file:
 
-```yaml
-default: "10.0"
-versions:
-  "9.4.5":
-    image: icr.io/ibm-messaging/mq:9.4.5.1-r1
-    caps: []                       # baseline
-  "10.0":
-    image: icr.io/ibm-messaging/mq:10.0.0.0-r1
-    caps: [gskit9, native-ha-irr, multi-cert-labels]
+```json
+{
+  "default": "9.4.5",
+  "versions": {
+    "9.4.5": {
+      "image": "icr.io/ibm-messaging/mq:9.4.5.1-r1",
+      "caps": []
+    },
+    "10.0": {
+      "image": "icr.io/ibm-messaging/mq:10.0.0.0-r1",
+      "caps": ["chstatus-quantum-safe"]
+    }
+  }
+}
 ```
 
+`default` is `9.4.5` today and flips to `10.0` once
+`mq-rest-admin-common#217` lands (see Dependencies & sequencing).
+`chstatus-quantum-safe` marks that 10.0 emits `SSLQS`/`SSLQSR` on
+`DISPLAY CHSTATUS`.
+
 - **Aliases** are human-friendly (`9.4.5`, `10.0`); full image tags live
-  in one column so they are easy to bump.
-- **`caps`** are short, stable tokens for *testable* version
-  differences. The list starts near-empty and grows only as we identify
-  real, asserted differences (YAGNI). A cap token is added here once a
-  consuming test actually keys off it.
+  in one column so they are easy to bump. `10.0.0.0-r1` is confirmed as
+  the only 10.x multi-arch tag on icr.io (per #148), and `9.4.5.1-r1` is
+  the highest 9.x multi-arch tag.
+- **`caps`** are short, stable tokens for *coarse, environment-level*
+  capabilities a test legitimately gates on at the environment level —
+  e.g. "this version emits the quantum-safe CHSTATUS attributes." They
+  are **not** a mirror of `mapping-data.json`. Fine-grained REST
+  attribute-to-field mappings stay in `mq-rest-admin-common`, keyed by
+  version, as the single source of truth; duplicating them here would
+  create two catalogs that drift. The list starts minimal and grows only
+  when a consuming test actually keys off a token (YAGNI).
 - **`default`** names the alias used when no version is selected.
 
-The exact `10.0.0.0-r1` tag is a placeholder to be confirmed against the
-published IBM MQ for Developers container tags during implementation.
+The first real token, `chstatus-quantum-safe`, names exactly the surface
+that broke under #148: 10.0's new `SSLQS`/`SSLQSR` attributes on
+`DISPLAY CHSTATUS`. It exists so a test can assert presence on 10.0 and
+absence on 9.4.5 without re-encoding the field mappings that
+`mq-rest-admin-common#217` owns.
 
 ## Component 2 — local dev (lifecycle scripts)
 
 A shared helper `scripts/mq_resolve_version.sh` performs the manifest
-lookup so the lifecycle scripts do not each reimplement parsing. The
-existing scripts (`mq_start.sh`, `mq_reset.sh`, `mq_seed.sh`,
-`mq_verify.sh`, `mq_stop.sh`) source it.
+lookup (via `jq`) so the lifecycle scripts do not each reimplement
+parsing. The existing scripts (`mq_start.sh`, `mq_reset.sh`,
+`mq_seed.sh`, `mq_verify.sh`, `mq_stop.sh`) source it. **`jq` becomes a
+declared local prerequisite** (alongside Docker and curl in CLAUDE.md);
+the helper fails loudly with an install hint if `jq` is absent rather
+than silently degrading.
 
 Behavior:
 
@@ -97,7 +149,8 @@ Behavior:
   `MQ_IMAGE` for the existing compose flow, and exports `MQ_VERSION` and
   `MQ_CAPS` into the environment so a locally-run test suite sees the
   same signal CI provides.
-- No `MQ_VERSION` set → use the manifest `default` (`10.0`).
+- No `MQ_VERSION` set → use the manifest `default` (currently `9.4.5`;
+  `10.0` once #217 lands).
 - **Unknown alias → hard fail**, printing the list of valid aliases. No
   silent fallback to default, which would mask typos and silently test
   the wrong version. (Consistent with the no-silent-failures policy.)
@@ -106,21 +159,48 @@ Behavior:
 `${MQ_IMAGE:-...}`. The scripts now set `MQ_IMAGE` from the manifest
 rather than relying on the compose default.
 
+### Per-version data isolation (volume lifecycle)
+
+The compose file mounts named volumes (`qm1data`, `qm2data`) that persist
+across `mq_stop.sh` (it runs `down`, not `down -v`). Because MQ
+queue-manager data migration is one-way, booting one version on another
+version's `/var/mqm` fails or corrupts. With "select one per run", a
+local developer *will* switch versions, so the data must be isolated per
+version.
+
+**Mechanism:** the resolve helper sets `COMPOSE_PROJECT_NAME` to include
+the version alias (e.g. `mq-dev-10_0`, `mq-dev-9_4_5`; dots normalized to
+underscores for Docker's naming rules). Docker prefixes volume and
+container names with the project name, so each version gets its own
+isolated `/var/mqm`. Switching versions is then **non-destructive** — the
+9.4.5 data survives while you exercise 10.0, and vice versa.
+
+Consequences threaded through the scripts:
+
+- `mq_stop.sh` / `mq_reset.sh` operate on the **same** project name the
+  resolve helper computes for the selected version, so they stop and
+  (for reset) wipe the right environment rather than a default-named one.
+- This reuses the isolation the `setup-mq` action already exposes via its
+  `project-name` input; in CI each matrix leg additionally runs on a
+  fresh runner, so cross-version contamination cannot occur there.
+- Disk cost: one `/var/mqm` pair per version the developer has started.
+  `mq_reset.sh` (now project-scoped) reclaims a version's volumes.
+
 ## Component 3 — CI mechanism
 
 A GitHub Actions matrix is evaluated before any checkout, so it cannot
 read a file directly. Two pieces bridge that gap.
 
-### 3a. Reusable workflow `mq-versions.yml`
+### 3a. Reusable workflow `.github/workflows/mq-versions.yml`
 
-A new reusable *workflow* (distinct from the manifest file of the same
-base name; final filename to be disambiguated during implementation,
-e.g. `.github/workflows/mq-versions.yml`). A single small job:
+A new reusable *workflow*. The manifest is now `mq-versions.json`, so the
+old name collision with the manifest is gone; the workflow keeps the
+descriptive `mq-versions.yml` filename. A single small job:
 
 - checks out this repo,
-- reads the manifest,
+- reads `mq-versions.json` with `jq` (present on GitHub-hosted runners),
 - emits outputs `versions` (JSON array of aliases, e.g.
-  `["9.4.5","10.0"]`) and `default`.
+  `["9.4.5","10.0"]`, via `jq -c '.versions | keys'`) and `default`.
 
 Consumers add one `needs:`-able job and feed `fromJSON(...)` into their
 own matrix:
@@ -128,17 +208,23 @@ own matrix:
 ```yaml
 jobs:
   mq-versions:
-    uses: mq-rest-admin-project/mq-rest-admin-dev-environment/.github/workflows/mq-versions.yml@v1
+    uses: mq-rest-admin-project/mq-rest-admin-dev-environment/.github/workflows/mq-versions.yml@vX.Y
   integration:
     needs: mq-versions
     strategy:
       matrix:
         mq: ${{ fromJSON(needs.mq-versions.outputs.versions) }}
     steps:
-      - uses: mq-rest-admin-project/mq-rest-admin-dev-environment/.github/actions/setup-mq@v1
+      - uses: mq-rest-admin-project/mq-rest-admin-dev-environment/.github/actions/setup-mq@vX.Y
         with:
           mq-version: ${{ matrix.mq }}
 ```
+
+`@vX.Y` is the **rolling major-minor tag** — the standard, recommended
+consumption ref for both the workflow and the action. It moves forward
+within a minor series, so consumers stay current without editing the ref
+(see Mechanism versioning). Consumers substitute the current series
+(e.g. `@v1.2`).
 
 Consumers keep control of their own test command and may subset the
 sweep (for example `default`-only on draft PRs, full sweep on main) —
@@ -155,12 +241,28 @@ they simply never hardcode the version list.
 
 The action resolves the alias via the same manifest the scripts use.
 
-### Mechanism versioning
+### Mechanism versioning & consumption-ref contract
 
-The workflow and action are consumed at a tag (`@v1`). Adding an MQ
-version to the manifest is a **non-breaking** change for consumers:
-their matrix simply grows on the next run with no consumer edit. That is
-the payoff of centralizing the version set.
+**Standard consumption ref: the rolling major-minor tag `vX.Y`.** This
+repo already publishes moving minor tags (`v1.1`, `v1.2`) and immutable
+patch tags (`v1.2.4`); the agreed convention is that consumers track the
+rolling `vX.Y` tag for both the reusable workflow and the action. (No
+bare `v1` major tag is used.)
+
+The workflow and action are new capabilities, so consumers reference the
+`vX.Y` series at or after the release that introduces them.
+
+The headline benefit — *add a version to the manifest and every
+consumer's matrix grows on the next run, with no consumer edit* — follows
+directly from tracking the rolling tag: a new MQ version ships in a patch
+release on the same `vX.Y` series, and consumers pick it up automatically.
+A consumer that instead pins an immutable patch tag (`@v1.2.4`) is frozen
+at that manifest snapshot — supported, but it opts out of auto-sync.
+
+Adding an MQ version is a **non-breaking** change to the manifest (patch
+bump on the current `vX.Y`); removing or renaming an alias, or changing
+an action input/output, is breaking and rides a minor/major bump — which,
+by definition, moves consumers to a new `vX.Y` series deliberately.
 
 ## Seed data across versions
 
@@ -170,41 +272,86 @@ the payoff of centralizing the version set.
 - **No per-version overlays yet** (YAGNI). If a future version needs
   version-specific objects, add an optional `seed/overlays/<alias>/`
   directory that `mq_seed.sh` layers on when present. Not designed now.
-- `mq_verify.sh` becomes version-aware via `MQ_CAPS`: baseline objects
-  are checked on all versions; capability-gated checks run only where the
-  capability is present.
+- `mq_verify.sh` checks the baseline **seed objects** on every version
+  (version-blind — seed objects are the same across versions). Separately
+  and optionally, it may use `MQ_CAPS` to assert version-specific
+  **REST-attribute** behavior (e.g. `SSLQS`/`SSLQSR` present on 10.0).
+  These are two distinct axes — seed-object presence vs version attribute
+  surface — and the spec keeps them separate rather than gating seed
+  checks on caps.
 
-## Backward-compatibility verification
+## Backward-compatibility status
 
 The two-version matrix is the safety net: the full suite runs against
 9.4.5 and 10.0, so any divergence surfaces as a CI failure on one leg.
+But the headline divergence is already known, not something the matrix
+will "discover":
 
-Two risks to probe deliberately, derived from the MQ 10.0 change
-analysis:
+1. **Additive REST attributes — CONFIRMED, already broke (#148).** 10.0
+   emits `SSLQS`/`SSLQSR` on `DISPLAY CHSTATUS`; the strict mapper in
+   `mq-rest-admin-common` raised on the unmapped attributes and the
+   integration gate failed. The fix is the `mapping-data.json` update
+   tracked in `mq-rest-admin-common#217`. **Until that lands, a 10.0
+   matrix leg against the current fleet will red-light by construction.**
+   This spec therefore sequences the 10.0 leg behind #217 (see
+   Dependencies & sequencing) rather than pretending the matrix is green
+   on day one.
+2. **GSKit 9 / post-quantum TLS — to probe.** GSKit is upgraded to v9 in
+   10.0 (FIPS 203 ML-KEM). Cipher-negotiation on the HTTPS path to
+   `mqweb` may change; watch for handshake issues in the REST clients.
+   This one is genuinely unverified, unlike (1).
 
-1. **GSKit 9 / post-quantum TLS.** GSKit is upgraded to v9 in 10.0,
-   bringing FIPS 203 ML-KEM support. Cipher-negotiation behavior on the
-   HTTPS path to `mqweb` may change. Watch for handshake/cipher issues
-   in the REST clients.
-2. **Additive REST attributes.** New object attributes may appear in
-   10.0 REST responses. Confirm strict deserializers tolerate unknown
-   fields rather than erroring.
-
-**Open action, not resolved by this spec:** verify these against the IBM
-MQ administrative REST API changelog/docs (not just the features-by-
-version table) before declaring 10.0 a drop-in. Stated separately
-because the change analysis describes feature areas (HA/CRR, Kafka,
-Console, containers) that are largely orthogonal to the admin REST API
-and notes 10.0 LTS is mostly a repackaging of 9.4.x CD — but that is an
-inference, not a confirmed read of the REST API changelog.
+**Open action, not resolved by this spec:** beyond `SSLQS`/`SSLQSR`,
+check the IBM admin REST API changelog for *other* additive 10.0
+attributes the mapper will need, so #217 is scoped completely rather than
+fixing only the attributes that happened to surface first. The MQ 10.0
+change analysis describes feature areas (HA/CRR, Kafka, Console,
+containers) largely orthogonal to the admin REST API, but that is an
+inference, not a confirmed read of the changelog.
 
 Reference: IBM MQ features-by-version table —
 <https://www.ibm.com/docs/en/ibm-mq/10.0.x?topic=information-mq-features-by-version>
 
+## Dependencies & sequencing
+
+This mechanism touches two repos and must land in order:
+
+1. **`mq-rest-admin-common#217` (v10 mapper enablement)** — adds the
+   `SSLQS`/`SSLQSR` (and any other missing 10.0) mappings to
+   `mapping-data.json`. This is the prerequisite: without it, 10.0 fails
+   the mapper regardless of how good the environment mechanism is.
+2. **This repo (the environment mechanism)** — manifest, scripts, action,
+   reusable workflow. Can be *built* in parallel with #217, but the
+   `default` should not flip to `10.0` for the fleet, and consumers
+   should not add a non-allow-failure 10.0 matrix leg, until #217 has
+   landed and the mappers accept 10.0 responses.
+3. **Consuming-repo adoption** (separate cycle, per repo) — wires the
+   reusable workflow + action into each language repo's CI and adds any
+   version-conditional tests.
+
+**Coordination note on `default: "10.0"`.** The manifest defaulting to
+10.0 is the agreed end-state, but flipping it is the step that makes
+every default-only consumer start exercising 10.0. Treat the default
+flip as a deliberate switch gated on #217, not as something that ships
+silently with the mechanism. Until then the manifest ships with
+`default: "9.4.5"`. Since `mq-versions.json` cannot carry comments, the
+intended end-state (10.0 once the mapper lands) is recorded here and in
+the repo docs rather than inline; flipping `default` to `10.0` is a
+one-line follow-up gated on #217.
+
+Related history/tracking: #147 (origin of the pin), #148 (the pin
+itself), `mq-rest-admin-common#217` (mapper enablement).
+
 ## Out of scope (named, not designed here)
 
-1. **Consuming-repo adoption** across the five languages — one spec per
-   repo, building on this mechanism.
+1. **Consuming-repo adoption** across the language repos / fleet — one
+   spec per repo, building on this mechanism. (The repo docs currently
+   name `pymqrest`, `mq-rest-admin`, and planned `pymqpcf`; #148 refers
+   to "every language repo" and `mq-rest-admin-common`, so the actual
+   fleet is larger — adoption specs should enumerate it explicitly.)
+2. **The `mapping-data.json` / mapper fix itself** — owned by
+   `mq-rest-admin-common#217`, not this repo. This spec depends on it but
+   does not design it.
 2. **Version-lifecycle policy** — how long to keep 9.4.x, when to add
    10.x CD releases. Editorial; lives in docs and is driven by manifest
    edits.
@@ -223,5 +370,11 @@ Reference: IBM MQ features-by-version table —
   get its integration suite run once per manifest version, with no
   hardcoded version list.
 - Tests can read the resolved version and capabilities to make
-  version-conditional assertions/skips.
+  version-conditional assertions/skips (e.g. assert `SSLQS`/`SSLQSR`
+  present on 10.0, absent on 9.4.5).
 - The shared seed applies cleanly on every manifest version.
+- **Once `mq-rest-admin-common#217` has landed**, the 10.0 matrix leg
+  passes against the fleet and the manifest `default` can be flipped to
+  `10.0`. Before that, the mechanism is complete but 10.0 runs as an
+  allow-failure / non-default leg — it does not gate merges on a failure
+  that is expected until the mapper is fixed.

--- a/docs/plans/2026-06-23-multi-version-mq-testing-design.md
+++ b/docs/plans/2026-06-23-multi-version-mq-testing-design.md
@@ -301,13 +301,14 @@ will "discover":
    `mqweb` may change; watch for handshake issues in the REST clients.
    This one is genuinely unverified, unlike (1).
 
-**Open action, not resolved by this spec:** beyond `SSLQS`/`SSLQSR`,
-check the IBM admin REST API changelog for *other* additive 10.0
-attributes the mapper will need, so #217 is scoped completely rather than
-fixing only the attributes that happened to surface first. The MQ 10.0
-change analysis describes feature areas (HA/CRR, Kafka, Console,
+**Open action, tracked in `mq-rest-admin-common#219`:** beyond
+`SSLQS`/`SSLQSR`, enumerate *all* additive/changed 10.0 admin REST
+attributes from the IBM changelog so `#217` is scoped completely rather
+than fixing only the attributes that happened to surface first. The MQ
+10.0 change analysis describes feature areas (HA/CRR, Kafka, Console,
 containers) largely orthogonal to the admin REST API, but that is an
-inference, not a confirmed read of the changelog.
+inference, not a confirmed read of the changelog — which is exactly what
+#219 will resolve.
 
 Reference: IBM MQ features-by-version table —
 <https://www.ibm.com/docs/en/ibm-mq/10.0.x?topic=information-mq-features-by-version>
@@ -340,7 +341,9 @@ the repo docs rather than inline; flipping `default` to `10.0` is a
 one-line follow-up gated on #217.
 
 Related history/tracking: #147 (origin of the pin), #148 (the pin
-itself), `mq-rest-admin-common#217` (mapper enablement).
+itself), `mq-rest-admin-common#217` (mapper enablement),
+`mq-rest-admin-common#219` (complete enumeration of changed 10.0 REST
+attributes that scopes #217).
 
 ## Out of scope (named, not designed here)
 

--- a/docs/plans/2026-06-23-multi-version-mq-testing-design.md
+++ b/docs/plans/2026-06-23-multi-version-mq-testing-design.md
@@ -1,0 +1,227 @@
+# Multi-version MQ testing — design
+
+- **Date:** 2026-06-23
+- **Issue:** #157
+- **Status:** Approved design; implementation plan to follow
+- **Scope:** Mechanism in this repo only. Consuming-repo adoption is
+  deferred to separate per-repo cycles.
+
+## Problem
+
+The dev environment is locked to a single IBM MQ version (9.4.5.1). MQ
+10.0 LTS went GA on 2026-06-16. We want to make 10.0 the primary
+development and integration-test target for the mq-rest-admin tree while
+keeping 9.4.5 in the test matrix, and to add future 10.x CD releases
+independently as they ship — without consuming repos hardcoding or
+drifting on the version set.
+
+A secondary driver is a backward-compatibility question: is 10.0 a
+drop-in for the administrative REST API? The mechanism below makes that
+question answerable by running the same suite against both versions.
+
+## Decisions (resolved during brainstorming)
+
+1. **Execution model: select one version per run.** One version runs at
+   a time on the stable contract ports (QM1 9443, QM2 9444, QM1/QM2 MQ
+   listeners 1414/1415, users `mqadmin`/`mqreader`). CI sweeps versions
+   with a matrix that runs the whole suite once per version. No
+   side-by-side topology.
+2. **Source of truth: a manifest in this repo.** A single
+   `mq-versions.yml` maps version aliases to image tags and capability
+   tokens and names a `default`. Scripts, the action, and a reusable
+   workflow all read it. Adding/retiring a version is a one-line edit
+   here.
+3. **Default version: `10.0`.** When no version is selected, the
+   environment uses the manifest `default`, which is `10.0`.
+4. **Version-aware tests: yes.** The environment exports the resolved
+   version and a capability map so consuming-repo tests can assert
+   version-specific behavior or skip where a capability is absent,
+   instead of collapsing to a lowest-common-denominator suite.
+
+## Architecture
+
+The manifest is the single lever. Three touch-points read it; the
+environment contract stays invariant across versions because only one
+version runs at a time on the same ports.
+
+```text
+mq-versions.yml  (source of truth)
+   |
+   +-- scripts/        mq_resolve_version.sh -> MQ_IMAGE/MQ_VERSION/MQ_CAPS  (local dev)
+   +-- setup-mq action mq-version input  -> resolved version/image/caps outputs (CI per matrix leg)
+   +-- mq-versions.yml workflow  emits version list as matrix JSON (CI matrix source)
+```
+
+**Contract invariant.** Because exactly one version runs at a time on
+the same ports / queue-manager names / users, the environment contract
+documented in `CLAUDE.md` and `README.md` is byte-for-byte identical
+across versions. Consumers point at the same REST URLs regardless of
+version; the only thing that varies is an out-of-band version *signal*.
+
+## Component 1 — the version manifest
+
+New file `mq-versions.yml` (repo root):
+
+```yaml
+default: "10.0"
+versions:
+  "9.4.5":
+    image: icr.io/ibm-messaging/mq:9.4.5.1-r1
+    caps: []                       # baseline
+  "10.0":
+    image: icr.io/ibm-messaging/mq:10.0.0.0-r1
+    caps: [gskit9, native-ha-irr, multi-cert-labels]
+```
+
+- **Aliases** are human-friendly (`9.4.5`, `10.0`); full image tags live
+  in one column so they are easy to bump.
+- **`caps`** are short, stable tokens for *testable* version
+  differences. The list starts near-empty and grows only as we identify
+  real, asserted differences (YAGNI). A cap token is added here once a
+  consuming test actually keys off it.
+- **`default`** names the alias used when no version is selected.
+
+The exact `10.0.0.0-r1` tag is a placeholder to be confirmed against the
+published IBM MQ for Developers container tags during implementation.
+
+## Component 2 — local dev (lifecycle scripts)
+
+A shared helper `scripts/mq_resolve_version.sh` performs the manifest
+lookup so the lifecycle scripts do not each reimplement parsing. The
+existing scripts (`mq_start.sh`, `mq_reset.sh`, `mq_seed.sh`,
+`mq_verify.sh`, `mq_stop.sh`) source it.
+
+Behavior:
+
+- `MQ_VERSION=10.0 scripts/mq_start.sh` resolves the alias, exports
+  `MQ_IMAGE` for the existing compose flow, and exports `MQ_VERSION` and
+  `MQ_CAPS` into the environment so a locally-run test suite sees the
+  same signal CI provides.
+- No `MQ_VERSION` set → use the manifest `default` (`10.0`).
+- **Unknown alias → hard fail**, printing the list of valid aliases. No
+  silent fallback to default, which would mask typos and silently test
+  the wrong version. (Consistent with the no-silent-failures policy.)
+
+`docker-compose.yml` is unchanged: it already reads
+`${MQ_IMAGE:-...}`. The scripts now set `MQ_IMAGE` from the manifest
+rather than relying on the compose default.
+
+## Component 3 — CI mechanism
+
+A GitHub Actions matrix is evaluated before any checkout, so it cannot
+read a file directly. Two pieces bridge that gap.
+
+### 3a. Reusable workflow `mq-versions.yml`
+
+A new reusable *workflow* (distinct from the manifest file of the same
+base name; final filename to be disambiguated during implementation,
+e.g. `.github/workflows/mq-versions.yml`). A single small job:
+
+- checks out this repo,
+- reads the manifest,
+- emits outputs `versions` (JSON array of aliases, e.g.
+  `["9.4.5","10.0"]`) and `default`.
+
+Consumers add one `needs:`-able job and feed `fromJSON(...)` into their
+own matrix:
+
+```yaml
+jobs:
+  mq-versions:
+    uses: mq-rest-admin-project/mq-rest-admin-dev-environment/.github/workflows/mq-versions.yml@v1
+  integration:
+    needs: mq-versions
+    strategy:
+      matrix:
+        mq: ${{ fromJSON(needs.mq-versions.outputs.versions) }}
+    steps:
+      - uses: mq-rest-admin-project/mq-rest-admin-dev-environment/.github/actions/setup-mq@v1
+        with:
+          mq-version: ${{ matrix.mq }}
+```
+
+Consumers keep control of their own test command and may subset the
+sweep (for example `default`-only on draft PRs, full sweep on main) —
+they simply never hardcode the version list.
+
+### 3b. `setup-mq` action additions
+
+- **New input:** `mq-version` (alias; defaults to the manifest
+  `default`).
+- **New outputs:** `mq-version` (resolved), `mq-image` (resolved tag),
+  `mq-caps` (JSON).
+- **Unchanged outputs:** `qm1-rest-url`, `qm2-rest-url` — the ports are
+  stable, so these do not vary by version.
+
+The action resolves the alias via the same manifest the scripts use.
+
+### Mechanism versioning
+
+The workflow and action are consumed at a tag (`@v1`). Adding an MQ
+version to the manifest is a **non-breaking** change for consumers:
+their matrix simply grows on the next run with no consumer edit. That is
+the payoff of centralizing the version set.
+
+## Seed data across versions
+
+- The shared seed (`seed/base-qm1.mqsc`, `seed/base-qm2.mqsc`) must apply
+  cleanly on **every** version in the manifest. This is now an invariant
+  of adding a version. `mq_seed.sh` already runs version-blind.
+- **No per-version overlays yet** (YAGNI). If a future version needs
+  version-specific objects, add an optional `seed/overlays/<alias>/`
+  directory that `mq_seed.sh` layers on when present. Not designed now.
+- `mq_verify.sh` becomes version-aware via `MQ_CAPS`: baseline objects
+  are checked on all versions; capability-gated checks run only where the
+  capability is present.
+
+## Backward-compatibility verification
+
+The two-version matrix is the safety net: the full suite runs against
+9.4.5 and 10.0, so any divergence surfaces as a CI failure on one leg.
+
+Two risks to probe deliberately, derived from the MQ 10.0 change
+analysis:
+
+1. **GSKit 9 / post-quantum TLS.** GSKit is upgraded to v9 in 10.0,
+   bringing FIPS 203 ML-KEM support. Cipher-negotiation behavior on the
+   HTTPS path to `mqweb` may change. Watch for handshake/cipher issues
+   in the REST clients.
+2. **Additive REST attributes.** New object attributes may appear in
+   10.0 REST responses. Confirm strict deserializers tolerate unknown
+   fields rather than erroring.
+
+**Open action, not resolved by this spec:** verify these against the IBM
+MQ administrative REST API changelog/docs (not just the features-by-
+version table) before declaring 10.0 a drop-in. Stated separately
+because the change analysis describes feature areas (HA/CRR, Kafka,
+Console, containers) that are largely orthogonal to the admin REST API
+and notes 10.0 LTS is mostly a repackaging of 9.4.x CD — but that is an
+inference, not a confirmed read of the REST API changelog.
+
+Reference: IBM MQ features-by-version table —
+<https://www.ibm.com/docs/en/ibm-mq/10.0.x?topic=information-mq-features-by-version>
+
+## Out of scope (named, not designed here)
+
+1. **Consuming-repo adoption** across the five languages — one spec per
+   repo, building on this mechanism.
+2. **Version-lifecycle policy** — how long to keep 9.4.x, when to add
+   10.x CD releases. Editorial; lives in docs and is driven by manifest
+   edits.
+3. **Contract documentation** — updating the environment-contract table
+   in `CLAUDE.md` / `README.md` to document version selection and the new
+   version signals. (Done as part of implementation, but the policy/
+   wording is editorial.)
+
+## Success criteria
+
+- A developer can run `MQ_VERSION=9.4.5 scripts/mq_start.sh` or
+  `MQ_VERSION=10.0 scripts/mq_start.sh` (or omit it for the default) and
+  get a working environment on the stable ports.
+- Unknown `MQ_VERSION` fails loudly with the valid alias list.
+- A consuming repo can call the reusable workflow + `setup-mq` action and
+  get its integration suite run once per manifest version, with no
+  hardcoded version list.
+- Tests can read the resolved version and capabilities to make
+  version-conditional assertions/skips.
+- The shared seed applies cleanly on every manifest version.

--- a/docs/plans/2026-06-23-multi-version-mq-testing-plan.md
+++ b/docs/plans/2026-06-23-multi-version-mq-testing-plan.md
@@ -1,0 +1,915 @@
+# Multi-version MQ testing — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps
+> use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the MQ dev environment select among multiple MQ versions
+(9.4.5 and 10.0) from a single JSON manifest, run one version per run on
+the stable contract ports, and expose the resolved version to CI matrices
+and tests.
+
+**Architecture:** A single `mq-versions.json` manifest is the source of
+truth. A sourced bash helper (`mq_resolve_version.sh`) resolves an alias
+to an image tag, capability list, and a per-version Compose project name,
+exporting them for the lifecycle scripts. A second helper emits the
+version list as JSON for GitHub Actions matrices. The `setup-mq` action
+gains a `mq-version` input and version/image/caps outputs; a reusable
+workflow publishes the matrix. Plain-bash tests under `tests/` cover the
+helpers and run in a dedicated CI workflow.
+
+**Tech Stack:** Bash, `jq` (already in the validation container), Docker
+Compose, GitHub Actions (composite action + reusable workflow).
+
+## Global Constraints
+
+Every task's requirements implicitly include this section.
+
+- **Work only inside the worktree:** `.worktrees/issue-157-multi-version-mq/`
+  on branch `feature/157-multi-version-mq`. The main worktree is read-only.
+- **Git/GitHub wrappers only:** use `vrg-git` (not `git`), `vrg-gh` (not
+  `gh`), and `vrg-commit` for commits. Raw `git commit` is denied.
+  `vrg-commit` signature: `vrg-commit --type <feat|fix|docs|style|refactor|test|chore|ci|build|revert> --scope <scope> --message <msg> [--body <body>]`.
+- **Commit trailer:** end every commit body with
+  `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+- **No heredocs in Bash tool calls** (`<<EOF` is blocked) — create files
+  with the editor/Write tool, not `cat <<EOF`.
+- **Validation is one command, run from the worktree:**
+  `vrg-container-run -- vrg-validate` (runs markdownlint, shellcheck,
+  yamllint, actionlint). Do not invoke linters individually.
+- **Run the bash tests explicitly:** `bash tests/<name>.sh` from the
+  worktree root (CWD = repo root).
+- **`jq` is the only new dependency.** It is present in CI and the
+  container; it becomes a declared local prerequisite. Do not add `yq`,
+  `bats`, or any other tool.
+- **Manifest is JSON** (`mq-versions.json`) — no comments allowed in the
+  file; rationale lives in docs.
+- **`default` stays `"9.4.5"`.** Flipping the default to `"10.0"` is a
+  follow-up gated on `mq-rest-admin-common#217` and is NOT part of this
+  plan.
+- **Contract invariance:** ports (9443/9444, 1414/1415), queue-manager
+  names (QM1/QM2), and users (`mqadmin`/`mqreader`) do not change.
+- **Consumption ref:** consumers track the rolling `vX.Y` major-minor tag
+  (documentation only in this plan; no release is cut here).
+- **Spec:** `docs/plans/2026-06-23-multi-version-mq-testing-design.md`.
+
+---
+
+## File Structure
+
+**Create:**
+- `mq-versions.json` — version manifest (source of truth).
+- `scripts/mq_resolve_version.sh` — sourced helper: alias → `MQ_IMAGE`,
+  `MQ_VERSION`, `MQ_CAPS`, `COMPOSE_PROJECT_NAME`; also a CLI print mode.
+- `scripts/mq_versions_matrix.sh` — prints the version list as a JSON
+  array for Actions matrices.
+- `.github/workflows/mq-versions.yml` — reusable workflow emitting
+  `versions` + `default` outputs.
+- `.github/workflows/shell-tests.yml` — runs `tests/*.sh` on PRs.
+- `tests/fixtures/mq-versions.json` — stable fixture manifest for tests.
+- `tests/test_manifest.sh` — validates the real manifest's structure.
+- `tests/test_resolve_version.sh` — covers the resolve helper.
+- `tests/test_versions_matrix.sh` — covers the matrix helper.
+- `tests/test_lifecycle_wiring.sh` — covers project-name propagation via
+  a stubbed `docker`.
+
+**Modify:**
+- `scripts/mq_start.sh`, `scripts/mq_stop.sh`, `scripts/mq_reset.sh`,
+  `scripts/mq_seed.sh`, `scripts/mq_verify.sh` — source the resolve
+  helper.
+- `.github/actions/setup-mq/action.yml` — `mq-version` input;
+  version/image/caps outputs; project-name becomes a prefix.
+- `CLAUDE.md`, `README.md`, `docs/site/docs/architecture/environment-contract.md`
+  — document version selection, `jq` prerequisite, and version signals.
+
+**Unchanged:** `scripts/mq_wait_ready.sh` (uses stable ports only),
+`config/docker-compose.yml` (already reads `${MQ_IMAGE:-...}`).
+
+---
+
+## Task 1: Version manifest + manifest validity test
+
+**Files:**
+- Create: `mq-versions.json`
+- Test: `tests/test_manifest.sh`
+
+**Interfaces:**
+- Produces: `mq-versions.json` with shape
+  `{ "default": <alias>, "versions": { <alias>: { "image": <str>, "caps": [<str>...] } } }`.
+  Consumed by Tasks 2 and 3.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_manifest.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Validates the real mq-versions.json manifest structure.
+set -uo pipefail
+
+MANIFEST="mq-versions.json"
+fails=0
+check() { # description, condition-exit-code
+  if [ "$2" -eq 0 ]; then echo "ok   - $1"; else echo "FAIL - $1"; fails=$((fails + 1)); fi
+}
+
+jq -e . "$MANIFEST" >/dev/null 2>&1; check "manifest is valid JSON" $?
+
+jq -e '.default as $d | .versions | has($d)' "$MANIFEST" >/dev/null 2>&1
+check "default names an existing version" $?
+
+jq -e '.versions | to_entries | all(.value.image | type == "string" and length > 0)' \
+  "$MANIFEST" >/dev/null 2>&1
+check "every version has a non-empty image" $?
+
+jq -e '.versions | to_entries | all(.value.caps | type == "array")' \
+  "$MANIFEST" >/dev/null 2>&1
+check "every version has a caps array" $?
+
+[ "$fails" -eq 0 ] && echo "PASS" || { echo "$fails check(s) failed"; exit 1; }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bash tests/test_manifest.sh`
+Expected: FAIL — `jq` errors because `mq-versions.json` does not exist
+(non-zero exit, "failed" output).
+
+- [ ] **Step 3: Create the manifest**
+
+Create `mq-versions.json`:
+
+```json
+{
+  "default": "9.4.5",
+  "versions": {
+    "9.4.5": {
+      "image": "icr.io/ibm-messaging/mq:9.4.5.1-r1",
+      "caps": []
+    },
+    "10.0": {
+      "image": "icr.io/ibm-messaging/mq:10.0.0.0-r1",
+      "caps": ["chstatus-quantum-safe"]
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bash tests/test_manifest.sh`
+Expected: PASS — all four checks `ok`, final line `PASS`.
+
+- [ ] **Step 5: Validate**
+
+Run: `vrg-container-run -- vrg-validate`
+Expected: completes clean (shellcheck passes on the new test script).
+
+- [ ] **Step 6: Commit**
+
+```bash
+vrg-git add mq-versions.json tests/test_manifest.sh
+vrg-commit --type feat --scope versions --message "add MQ version manifest" --body "$(printf 'Single source of truth mapping version aliases to image tags and\ncapability tokens, with a default. Defaults to 9.4.5; the 10.0 default\nflip is gated on mq-rest-admin-common#217.\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 2: Version-resolve helper
+
+**Files:**
+- Create: `scripts/mq_resolve_version.sh`
+- Create: `tests/fixtures/mq-versions.json`
+- Test: `tests/test_resolve_version.sh`
+
+**Interfaces:**
+- Consumes: a manifest at `$MQ_VERSIONS_FILE` (default `mq-versions.json`).
+- Produces:
+  - Function `mq_resolve <alias|"">` — when sourced, exports
+    `MQ_VERSION` (resolved alias), `MQ_IMAGE` (image tag), `MQ_CAPS`
+    (compact JSON array), `COMPOSE_PROJECT_NAME`
+    (`${MQ_PROJECT_NAME_PREFIX:-mq-dev}-<slug>`, slug = alias with `.`→`_`).
+    Empty/absent alias resolves the manifest `default`. Unknown alias →
+    message on stderr listing valid versions + non-zero return.
+  - CLI: `scripts/mq_resolve_version.sh [alias]` prints the resolved
+    image tag to stdout (used by tests and humans).
+  - These names are relied on by Task 4 (lifecycle scripts) and Task 5
+    (action).
+
+- [ ] **Step 1: Write the fixture**
+
+Create `tests/fixtures/mq-versions.json` (distinct image values so tests
+bind to the fixture, not the real manifest):
+
+```json
+{
+  "default": "9.4.5",
+  "versions": {
+    "9.4.5": { "image": "test/mq:9.4.5", "caps": [] },
+    "10.0": { "image": "test/mq:10.0", "caps": ["chstatus-quantum-safe"] }
+  }
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `tests/test_resolve_version.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Covers scripts/mq_resolve_version.sh in both CLI and sourced modes.
+set -uo pipefail
+
+export MQ_VERSIONS_FILE="tests/fixtures/mq-versions.json"
+HELPER="scripts/mq_resolve_version.sh"
+fails=0
+eq() { # description, actual, expected
+  if [ "$2" = "$3" ]; then echo "ok   - $1"
+  else echo "FAIL - $1: expected [$3] got [$2]"; fails=$((fails + 1)); fi
+}
+ok_nonzero() { # description, exit-code
+  if [ "$2" -ne 0 ]; then echo "ok   - $1"
+  else echo "FAIL - $1: expected non-zero exit"; fails=$((fails + 1)); fi
+}
+
+# CLI mode: explicit alias prints its image.
+eq "cli resolves 10.0 image" "$(bash "$HELPER" 10.0)" "test/mq:10.0"
+
+# CLI mode: no alias uses the manifest default (9.4.5).
+eq "cli no-arg uses default image" "$(bash "$HELPER")" "test/mq:9.4.5"
+
+# CLI mode: unknown alias fails and names valid versions.
+err="$(bash "$HELPER" bogus 2>&1)"; rc=$?
+ok_nonzero "cli unknown alias exits non-zero" "$rc"
+case "$err" in
+  *"unknown MQ version"*"9.4.5"*"10.0"*) echo "ok   - error lists valid versions" ;;
+  *) echo "FAIL - error message missing valid versions: $err"; fails=$((fails + 1)) ;;
+esac
+
+# Sourced mode: exports the full signal set for 10.0.
+( set -e
+  # shellcheck disable=SC1090
+  source "$HELPER"
+  mq_resolve 10.0
+  [ "$MQ_VERSION" = "10.0" ] || { echo "FAIL - sourced MQ_VERSION"; exit 1; }
+  [ "$MQ_IMAGE" = "test/mq:10.0" ] || { echo "FAIL - sourced MQ_IMAGE"; exit 1; }
+  [ "$MQ_CAPS" = '["chstatus-quantum-safe"]' ] || { echo "FAIL - sourced MQ_CAPS [$MQ_CAPS]"; exit 1; }
+  [ "$COMPOSE_PROJECT_NAME" = "mq-dev-10_0" ] || { echo "FAIL - sourced project name [$COMPOSE_PROJECT_NAME]"; exit 1; }
+  echo "ok   - sourced mode exports version/image/caps/project"
+) || fails=$((fails + 1))
+
+# Sourced mode: 9.4.5 caps default to [].
+( set -e
+  # shellcheck disable=SC1090
+  source "$HELPER"
+  mq_resolve 9.4.5
+  [ "$MQ_CAPS" = "[]" ] || { echo "FAIL - 9.4.5 caps [$MQ_CAPS]"; exit 1; }
+  echo "ok   - 9.4.5 caps default to []"
+) || fails=$((fails + 1))
+
+[ "$fails" -eq 0 ] && echo "PASS" || { echo "$fails check(s) failed"; exit 1; }
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `bash tests/test_resolve_version.sh`
+Expected: FAIL — `scripts/mq_resolve_version.sh` does not exist.
+
+- [ ] **Step 4: Write the helper**
+
+Create `scripts/mq_resolve_version.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Resolve an MQ version alias to its image, caps, and Compose project name.
+#
+# Source it and call mq_resolve to export the environment for the
+# lifecycle scripts, or run it directly to print the resolved image:
+#   source scripts/mq_resolve_version.sh && mq_resolve "${MQ_VERSION:-}"
+#   scripts/mq_resolve_version.sh 10.0   # prints the image tag
+set -euo pipefail
+
+MQ_VERSIONS_FILE="${MQ_VERSIONS_FILE:-mq-versions.json}"
+
+mq_resolve() {
+  command -v jq >/dev/null 2>&1 || {
+    echo "mq_resolve_version: jq is required but not installed." \
+         "Install jq: https://jqlang.github.io/jq/" >&2
+    return 1
+  }
+
+  local alias="${1:-}"
+  if [ -z "$alias" ]; then
+    alias="$(jq -r '.default' "$MQ_VERSIONS_FILE")"
+  fi
+
+  local image
+  if ! image="$(jq -er --arg v "$alias" '.versions[$v].image' "$MQ_VERSIONS_FILE" 2>/dev/null)"; then
+    local known
+    known="$(jq -r '.versions | keys | join(", ")' "$MQ_VERSIONS_FILE")"
+    echo "mq_resolve_version: unknown MQ version '$alias'. Valid versions: $known." >&2
+    return 1
+  fi
+
+  MQ_VERSION="$alias"
+  MQ_IMAGE="$image"
+  MQ_CAPS="$(jq -c --arg v "$alias" '.versions[$v].caps // []' "$MQ_VERSIONS_FILE")"
+  COMPOSE_PROJECT_NAME="${MQ_PROJECT_NAME_PREFIX:-mq-dev}-${alias//./_}"
+  export MQ_VERSION MQ_IMAGE MQ_CAPS COMPOSE_PROJECT_NAME
+}
+
+# Executed directly (not sourced): print the resolved image and exit.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  mq_resolve "${1:-}"
+  echo "$MQ_IMAGE"
+fi
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `bash tests/test_resolve_version.sh`
+Expected: PASS — every check `ok`, final line `PASS`.
+
+- [ ] **Step 6: Validate**
+
+Run: `vrg-container-run -- vrg-validate`
+Expected: clean (shellcheck passes; the `SC1090` source is annotated).
+
+- [ ] **Step 7: Commit**
+
+```bash
+vrg-git add scripts/mq_resolve_version.sh tests/fixtures/mq-versions.json tests/test_resolve_version.sh
+vrg-commit --type feat --scope scripts --message "add version-resolve helper" --body "$(printf 'Resolves an MQ version alias to its image tag, capability list, and a\nper-version Compose project name. Sourced by the lifecycle scripts;\nfails loudly on an unknown alias and on missing jq.\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 3: Matrix-list helper
+
+**Files:**
+- Create: `scripts/mq_versions_matrix.sh`
+- Test: `tests/test_versions_matrix.sh`
+
+**Interfaces:**
+- Consumes: manifest at `$MQ_VERSIONS_FILE` (default `mq-versions.json`).
+- Produces: prints a compact JSON array of version aliases (sorted by
+  `jq keys`) to stdout, e.g. `["10.0","9.4.5"]`. Consumed by the reusable
+  workflow in Task 6.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_versions_matrix.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Covers scripts/mq_versions_matrix.sh against the fixture manifest.
+set -uo pipefail
+
+export MQ_VERSIONS_FILE="tests/fixtures/mq-versions.json"
+out="$(bash scripts/mq_versions_matrix.sh)"
+if [ "$out" = '["10.0","9.4.5"]' ]; then
+  echo "ok   - emits sorted JSON array of aliases"; echo "PASS"
+else
+  echo "FAIL - expected [\"10.0\",\"9.4.5\"] got [$out]"; exit 1
+fi
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bash tests/test_versions_matrix.sh`
+Expected: FAIL — `scripts/mq_versions_matrix.sh` does not exist.
+
+- [ ] **Step 3: Write the helper**
+
+Create `scripts/mq_versions_matrix.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Print the manifest's version aliases as a compact JSON array, for use
+# as a GitHub Actions matrix (consumed via fromJSON).
+set -euo pipefail
+
+MQ_VERSIONS_FILE="${MQ_VERSIONS_FILE:-mq-versions.json}"
+jq -c '.versions | keys' "$MQ_VERSIONS_FILE"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bash tests/test_versions_matrix.sh`
+Expected: PASS.
+
+- [ ] **Step 5: Validate**
+
+Run: `vrg-container-run -- vrg-validate`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+vrg-git add scripts/mq_versions_matrix.sh tests/test_versions_matrix.sh
+vrg-commit --type feat --scope scripts --message "add matrix-list helper" --body "$(printf 'Emits the manifest version aliases as a compact JSON array for the\nreusable workflow to feed a GitHub Actions matrix via fromJSON.\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 4: Wire lifecycle scripts to the resolve helper
+
+**Files:**
+- Modify: `scripts/mq_start.sh`, `scripts/mq_stop.sh`,
+  `scripts/mq_reset.sh`, `scripts/mq_seed.sh`, `scripts/mq_verify.sh`
+- Test: `tests/test_lifecycle_wiring.sh`
+
+**Interfaces:**
+- Consumes: `mq_resolve` from Task 2.
+- Produces: each lifecycle script, before any `docker compose` call,
+  sources the helper and resolves `${MQ_VERSION:-}` so `MQ_IMAGE` and
+  `COMPOSE_PROJECT_NAME` are exported for Compose.
+
+**Note on test scope:** `mq_stop.sh` is the cleanest end-to-end probe of
+the source→resolve→export→Compose chain because it has no readiness gate
+or curl. The test stubs `docker` to capture `COMPOSE_PROJECT_NAME`. The
+other four scripts get the identical two-line wiring and are covered by
+shellcheck (`vrg-validate`) plus this shared-helper test; full
+start/seed/verify behavior is exercised by the existing container-based
+flow, not unit tests.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_lifecycle_wiring.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Verifies a lifecycle script resolves the per-version Compose project
+# name and passes it to docker. Stubs `docker` on PATH to capture env.
+set -uo pipefail
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# Fake docker: record COMPOSE_PROJECT_NAME, then succeed.
+mkdir -p "$tmp/bin"
+{
+  echo '#!/usr/bin/env bash'
+  echo 'printf "%s" "${COMPOSE_PROJECT_NAME:-UNSET}" > "$CAPTURE_FILE"'
+  echo 'exit 0'
+} > "$tmp/bin/docker"
+chmod +x "$tmp/bin/docker"
+
+export CAPTURE_FILE="$tmp/project"
+PATH="$tmp/bin:$PATH" MQ_VERSION=10.0 bash scripts/mq_stop.sh >/dev/null 2>&1
+
+got="$(cat "$tmp/project" 2>/dev/null || echo MISSING)"
+if [ "$got" = "mq-dev-10_0" ]; then
+  echo "ok   - mq_stop.sh resolves per-version project name"; echo "PASS"
+else
+  echo "FAIL - expected mq-dev-10_0 got [$got]"; exit 1
+fi
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bash tests/test_lifecycle_wiring.sh`
+Expected: FAIL — `mq_stop.sh` does not yet source the helper, so
+`COMPOSE_PROJECT_NAME` is `UNSET` (not `mq-dev-10_0`).
+
+- [ ] **Step 3: Wire `mq_stop.sh`**
+
+Modify `scripts/mq_stop.sh` to:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resolve the selected MQ version so COMPOSE_PROJECT_NAME targets the
+# right per-version environment.
+# shellcheck source=scripts/mq_resolve_version.sh
+source scripts/mq_resolve_version.sh
+mq_resolve "${MQ_VERSION:-}"
+
+docker compose -f config/docker-compose.yml down
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bash tests/test_lifecycle_wiring.sh`
+Expected: PASS.
+
+- [ ] **Step 5: Wire the remaining four scripts**
+
+Add the same two-line block (after `set -euo pipefail`, before the first
+`docker compose` call) to each:
+
+`scripts/mq_start.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck source=scripts/mq_resolve_version.sh
+source scripts/mq_resolve_version.sh
+mq_resolve "${MQ_VERSION:-}"
+
+docker compose -f config/docker-compose.yml up -d
+
+# Block until both queue managers serve requests reliably.  The
+# readiness gate lives in mq_wait_ready.sh so seed/verify (and any
+# standalone caller) inherit the same stability window.
+scripts/mq_wait_ready.sh
+```
+
+`scripts/mq_reset.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck source=scripts/mq_resolve_version.sh
+source scripts/mq_resolve_version.sh
+mq_resolve "${MQ_VERSION:-}"
+
+docker compose -f config/docker-compose.yml down -v
+```
+
+(`mq_reset.sh` currently contains only the `down -v` line, so the full
+file after editing is exactly the four lines above plus the two-line
+source/resolve block — nothing else to preserve.)
+
+`scripts/mq_seed.sh` — add the block immediately after
+`set -euo pipefail`, keeping the existing `mq_wait_ready.sh` call and
+`runmqsc` lines unchanged:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck source=scripts/mq_resolve_version.sh
+source scripts/mq_resolve_version.sh
+mq_resolve "${MQ_VERSION:-}"
+
+# Don't seed until both queue managers serve requests — seeding (and
+# the verify/tests that follow) must not race container startup.
+scripts/mq_wait_ready.sh
+
+docker compose -f config/docker-compose.yml exec -T qm1 runmqsc QM1 < seed/base-qm1.mqsc || true
+docker compose -f config/docker-compose.yml exec -T qm2 runmqsc QM2 < seed/base-qm2.mqsc || true
+```
+
+`scripts/mq_verify.sh` — add the block immediately after
+`set -euo pipefail` (before the existing variable assignments), leaving
+the rest of the script unchanged:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck source=scripts/mq_resolve_version.sh
+source scripts/mq_resolve_version.sh
+mq_resolve "${MQ_VERSION:-}"
+```
+
+- [ ] **Step 6: Re-run the wiring test and validate**
+
+Run: `bash tests/test_lifecycle_wiring.sh`
+Expected: PASS.
+
+Run: `vrg-container-run -- vrg-validate`
+Expected: clean (shellcheck resolves the `source=` directives).
+
+- [ ] **Step 7: Commit**
+
+```bash
+vrg-git add scripts/mq_start.sh scripts/mq_stop.sh scripts/mq_reset.sh scripts/mq_seed.sh scripts/mq_verify.sh tests/test_lifecycle_wiring.sh
+vrg-commit --type feat --scope scripts --message "select MQ version in lifecycle scripts" --body "$(printf 'Each lifecycle script sources the resolve helper so MQ_IMAGE and a\nper-version COMPOSE_PROJECT_NAME are set before Compose runs. Switching\nversions locally no longer boots one version onto another versions\npersistent /var/mqm volume.\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 5: setup-mq action — version input and outputs
+
+**Files:**
+- Modify: `.github/actions/setup-mq/action.yml`
+
+**Interfaces:**
+- Consumes: `mq_resolve` from Task 2 (via a new resolve step).
+- Produces: action input `mq-version` (default `''` → manifest default);
+  outputs `mq-version`, `mq-image`, `mq-caps`. The existing
+  `qm1-rest-url`/`qm2-rest-url` outputs and the port inputs are
+  unchanged. The `project-name` input becomes the project-name *prefix*
+  (`MQ_PROJECT_NAME_PREFIX`); the helper appends the version slug.
+
+- [ ] **Step 1: Add the `mq-version` input**
+
+Under `inputs:` in `.github/actions/setup-mq/action.yml`, add:
+
+```yaml
+  mq-version:
+    description: MQ version alias from mq-versions.json (default: manifest default)
+    required: false
+    default: ''
+```
+
+- [ ] **Step 2: Add version/image/caps outputs**
+
+Under `outputs:`, add (keeping the existing URL outputs):
+
+```yaml
+  mq-version:
+    description: Resolved MQ version alias
+    value: ${{ steps.resolve.outputs.mq-version }}
+  mq-image:
+    description: Resolved MQ container image tag
+    value: ${{ steps.resolve.outputs.mq-image }}
+  mq-caps:
+    description: Capability tokens for the resolved version (JSON array)
+    value: ${{ steps.resolve.outputs.mq-caps }}
+```
+
+- [ ] **Step 3: Add a resolve step as the first step**
+
+As the first entry under `runs.steps:`:
+
+```yaml
+    - name: Resolve MQ version
+      id: resolve
+      shell: bash
+      working-directory: ${{ github.action_path }}/../../..
+      env:
+        MQ_VERSION: ${{ inputs.mq-version }}
+        MQ_PROJECT_NAME_PREFIX: ${{ inputs.project-name }}
+      run: |
+        # shellcheck source=scripts/mq_resolve_version.sh
+        source scripts/mq_resolve_version.sh
+        mq_resolve "${MQ_VERSION:-}"
+        {
+          echo "mq-version=$MQ_VERSION"
+          echo "mq-image=$MQ_IMAGE"
+          echo "mq-caps=$MQ_CAPS"
+        } >> "$GITHUB_OUTPUT"
+```
+
+- [ ] **Step 4: Pass version + prefix to the lifecycle steps**
+
+In each existing step (`Start MQ containers`, `Seed MQ objects`,
+`Verify MQ environment`), replace the `COMPOSE_PROJECT_NAME` env line with
+the version + prefix so the script's own `mq_resolve` computes the same
+project name. Each step's `env:` becomes, for example (Start):
+
+```yaml
+      env:
+        MQ_VERSION: ${{ inputs.mq-version }}
+        MQ_PROJECT_NAME_PREFIX: ${{ inputs.project-name }}
+        QM1_REST_PORT: ${{ inputs.qm1-rest-port }}
+        QM2_REST_PORT: ${{ inputs.qm2-rest-port }}
+        QM1_MQ_PORT: ${{ inputs.qm1-mq-port }}
+        QM2_MQ_PORT: ${{ inputs.qm2-mq-port }}
+```
+
+Apply the analogous change (drop `COMPOSE_PROJECT_NAME`, add `MQ_VERSION`
+and `MQ_PROJECT_NAME_PREFIX`) to the Seed and Verify steps, preserving
+each step's existing port env lines.
+
+- [ ] **Step 5: Validate**
+
+Run: `vrg-container-run -- vrg-validate`
+Expected: clean — `actionlint` passes on the updated action.
+
+- [ ] **Step 6: Commit**
+
+```bash
+vrg-git add .github/actions/setup-mq/action.yml
+vrg-commit --type feat --scope action --message "add mq-version input and version outputs to setup-mq" --body "$(printf 'The action resolves a version alias via the manifest, exposes\nmq-version/mq-image/mq-caps outputs for version-aware consumer tests,\nand treats project-name as a prefix the helper namespaces by version.\nPorts and REST URLs are unchanged.\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 6: Reusable workflow emitting the version matrix
+
+**Files:**
+- Create: `.github/workflows/mq-versions.yml`
+
+**Interfaces:**
+- Consumes: `scripts/mq_versions_matrix.sh` (Task 3) and the manifest's
+  `.default`.
+- Produces: a reusable workflow with `workflow_call` outputs `versions`
+  (JSON array) and `default` (alias). Consumed by downstream repos via
+  `fromJSON(needs.<job>.outputs.versions)`.
+
+- [ ] **Step 1: Create the workflow**
+
+Create `.github/workflows/mq-versions.yml`:
+
+```yaml
+name: MQ versions
+# Reusable workflow: publishes the supported MQ version list (from
+# mq-versions.json) so consuming repos can build a test matrix that
+# stays in sync with this repo. Consume at the rolling vX.Y tag.
+
+on:
+  workflow_call:
+    outputs:
+      versions:
+        description: JSON array of supported MQ version aliases
+        value: ${{ jobs.versions.outputs.versions }}
+      default:
+        description: Default MQ version alias
+        value: ${{ jobs.versions.outputs.default }}
+
+permissions:
+  contents: read
+
+jobs:
+  versions:
+    runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.read.outputs.versions }}
+      default: ${{ steps.read.outputs.default }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Read manifest
+        id: read
+        shell: bash
+        run: |
+          {
+            echo "versions=$(bash scripts/mq_versions_matrix.sh)"
+            echo "default=$(jq -r '.default' mq-versions.json)"
+          } >> "$GITHUB_OUTPUT"
+```
+
+- [ ] **Step 2: Sanity-check the emitted values locally**
+
+Run: `bash scripts/mq_versions_matrix.sh && jq -r '.default' mq-versions.json`
+Expected: `["10.0","9.4.5"]` then `9.4.5` — exactly what the workflow
+writes to `$GITHUB_OUTPUT`.
+
+- [ ] **Step 3: Validate**
+
+Run: `vrg-container-run -- vrg-validate`
+Expected: clean — `actionlint` passes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+vrg-git add .github/workflows/mq-versions.yml
+vrg-commit --type feat --scope ci --message "add reusable mq-versions matrix workflow" --body "$(printf 'Publishes the supported MQ version list and default from\nmq-versions.json as workflow_call outputs, so consuming repos build a\nversion matrix that auto-syncs when this repo adds a version. Consume at\nthe rolling vX.Y tag.\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 7: CI workflow to run the bash tests
+
+**Files:**
+- Create: `.github/workflows/shell-tests.yml`
+
+**Interfaces:**
+- Consumes: every `tests/*.sh`.
+- Produces: a PR-triggered job that runs the tests. Kept separate from
+  the vergil-managed `ci.yml` to avoid managed-config conflicts.
+
+- [ ] **Step 1: Create the workflow**
+
+Create `.github/workflows/shell-tests.yml`:
+
+```yaml
+name: Shell tests
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run bash tests
+        shell: bash
+        run: |
+          status=0
+          for t in tests/*.sh; do
+            echo "== $t =="
+            bash "$t" || status=1
+          done
+          exit "$status"
+```
+
+- [ ] **Step 2: Mirror locally what CI will do**
+
+Run: `for t in tests/*.sh; do echo "== $t =="; bash "$t" || exit 1; done`
+Expected: every test prints `PASS`; loop exits 0.
+
+- [ ] **Step 3: Validate**
+
+Run: `vrg-container-run -- vrg-validate`
+Expected: clean — `actionlint` and `yamllint` pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+vrg-git add .github/workflows/shell-tests.yml
+vrg-commit --type ci --scope tests --message "run bash tests on PRs" --body "$(printf 'Dedicated workflow that runs the tests/ bash scripts on pull requests,\nkept separate from the vergil-managed ci.yml.\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 8: Documentation
+
+**Files:**
+- Modify: `CLAUDE.md`, `README.md`,
+  `docs/site/docs/architecture/environment-contract.md`
+
+**Interfaces:**
+- Consumes: behavior delivered in Tasks 1–6.
+- Produces: docs covering version selection, the `jq` prerequisite, the
+  version signals, and the consumption ref. No code interface.
+
+- [ ] **Step 1: Update `CLAUDE.md`**
+
+In the "Environment Setup" list, add `jq` as a prerequisite:
+
+```markdown
+- **jq**: JSON processor used to read `mq-versions.json` for version
+  selection (`brew install jq` / `apt-get install jq`)
+```
+
+In "Container Lifecycle", document version selection:
+
+```markdown
+Select the MQ version with `MQ_VERSION` (alias from `mq-versions.json`;
+defaults to the manifest `default`). Each version uses its own Docker
+volumes, so switching is non-destructive:
+
+\`\`\`bash
+MQ_VERSION=10.0 scripts/mq_start.sh    # run 10.0
+MQ_VERSION=9.4.5 scripts/mq_start.sh   # run 9.4.5
+\`\`\`
+```
+
+In the Environment Contract table, change the Docker image row to:
+
+```markdown
+| Docker image | Selected via `mq-versions.json` (`MQ_VERSION`); default `icr.io/ibm-messaging/mq:9.4.5.1-r1` |
+```
+
+- [ ] **Step 2: Update `README.md`**
+
+Add a short "MQ version selection" subsection near the lifecycle/usage
+content:
+
+```markdown
+### MQ version selection
+
+`mq-versions.json` lists the supported MQ versions. Set `MQ_VERSION` to an
+alias (e.g. `10.0`, `9.4.5`) for any lifecycle script; omit it to use the
+manifest `default`. CI consumers call the reusable `mq-versions.yml`
+workflow to build a matrix and pass `mq-version` to the `setup-mq` action;
+track the rolling `vX.Y` tag so new versions are picked up automatically.
+```
+
+- [ ] **Step 3: Update the environment-contract doc**
+
+In `docs/site/docs/architecture/environment-contract.md`, update the
+Docker image entry to match Step 1 (selected via `mq-versions.json`,
+default `9.4.5.1-r1`) and add a sentence that the version is selectable
+while ports, queue-manager names, and users are invariant across
+versions.
+
+- [ ] **Step 4: Validate**
+
+Run: `vrg-container-run -- vrg-validate`
+Expected: clean — `markdownlint` passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+vrg-git add CLAUDE.md README.md docs/site/docs/architecture/environment-contract.md
+vrg-commit --type docs --scope env --message "document MQ version selection" --body "$(printf 'Document MQ_VERSION selection, the jq prerequisite, per-version volume\nisolation, the version signals, and the rolling vX.Y consumption tag.\nNote the contract (ports, QM names, users) is invariant across versions.\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+```
+
+---
+
+## Final verification
+
+- [ ] Run the whole test suite:
+  `for t in tests/*.sh; do echo "== $t =="; bash "$t" || exit 1; done`
+  — all `PASS`.
+- [ ] `vrg-container-run -- vrg-validate` — clean.
+- [ ] Optional live smoke (requires Docker):
+  `MQ_VERSION=9.4.5 scripts/mq_start.sh && scripts/mq_seed.sh && scripts/mq_verify.sh && scripts/mq_stop.sh`
+  then repeat with `MQ_VERSION=10.0` and confirm both come up on the same
+  ports with separate volumes (`docker volume ls | grep mq-dev`).
+- [ ] Push: `vrg-git push`. PR creation is gated to a human maintainer.
+
+## Out of scope (do not implement here)
+
+- Flipping the manifest `default` to `10.0` (gated on
+  `mq-rest-admin-common#217`).
+- The `mapping-data.json` / `SSLQS`/`SSLQSR` mapper fix (owned by
+  `mq-rest-admin-common#217`; enumeration in `#219`).
+- Consuming-repo adoption across the language fleet (separate per-repo
+  specs).
+- Per-version seed overlays (`seed/overlays/<alias>/`) — add only when a
+  version needs version-specific objects.
+- A `bats` test framework — possible future fleet-wide follow-up.

--- a/docs/site/docs/architecture/environment-contract.md
+++ b/docs/site/docs/architecture/environment-contract.md
@@ -16,8 +16,11 @@ coordination with all language libraries.
 | QM2 MQ listener | `localhost:1415` |
 | Admin user | `mqadmin` / `mqadmin` |
 | Reader user | `mqreader` / `mqreader` |
-| Docker image | `icr.io/ibm-messaging/mq:9.4.5.1-r1` |
+| Docker image | Selected via `mq-versions.json` (`MQ_VERSION`); default `icr.io/ibm-messaging/mq:9.4.5.1-r1` |
 | Docker network | `mq-dev-net` |
+
+The MQ version is selectable via `MQ_VERSION`; ports, queue-manager names,
+and users are invariant across versions.
 
 ## Seed objects
 

--- a/mq-versions.json
+++ b/mq-versions.json
@@ -1,0 +1,13 @@
+{
+  "default": "9.4.5",
+  "versions": {
+    "9.4.5": {
+      "image": "icr.io/ibm-messaging/mq:9.4.5.1-r1",
+      "caps": []
+    },
+    "10.0": {
+      "image": "icr.io/ibm-messaging/mq:10.0.0.0-r1",
+      "caps": ["chstatus-quantum-safe"]
+    }
+  }
+}

--- a/scripts/mq_reset.sh
+++ b/scripts/mq_reset.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# shellcheck source=scripts/mq_resolve_version.sh
+source scripts/mq_resolve_version.sh
+mq_resolve "${MQ_VERSION:-}"
+
 docker compose -f config/docker-compose.yml down -v

--- a/scripts/mq_resolve_version.sh
+++ b/scripts/mq_resolve_version.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Resolve an MQ version alias to its image, caps, and Compose project name.
+#
+# Source it and call mq_resolve to export the environment for the
+# lifecycle scripts, or run it directly to print the resolved image:
+#   source scripts/mq_resolve_version.sh && mq_resolve "${MQ_VERSION:-}"
+#   scripts/mq_resolve_version.sh 10.0   # prints the image tag
+set -euo pipefail
+
+MQ_VERSIONS_FILE="${MQ_VERSIONS_FILE:-mq-versions.json}"
+
+mq_resolve() {
+  command -v jq >/dev/null 2>&1 || {
+    echo "mq_resolve_version: jq is required but not installed." \
+         "Install jq: https://jqlang.github.io/jq/" >&2
+    return 1
+  }
+
+  local alias="${1:-}"
+  if [ -z "$alias" ]; then
+    alias="$(jq -r '.default' "$MQ_VERSIONS_FILE")"
+  fi
+
+  local image
+  if ! image="$(jq -er --arg v "$alias" '.versions[$v].image' "$MQ_VERSIONS_FILE" 2>/dev/null)"; then
+    local known
+    known="$(jq -r '.versions | keys_unsorted | join(", ")' "$MQ_VERSIONS_FILE")"
+    echo "mq_resolve_version: unknown MQ version '$alias'. Valid versions: $known." >&2
+    return 1
+  fi
+
+  MQ_VERSION="$alias"
+  MQ_IMAGE="$image"
+  MQ_CAPS="$(jq -c --arg v "$alias" '.versions[$v].caps // []' "$MQ_VERSIONS_FILE")"
+  COMPOSE_PROJECT_NAME="${MQ_PROJECT_NAME_PREFIX:-mq-dev}-${alias//./_}"
+  export MQ_VERSION MQ_IMAGE MQ_CAPS COMPOSE_PROJECT_NAME
+}
+
+# Executed directly (not sourced): print the resolved image and exit.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  mq_resolve "${1:-}"
+  echo "$MQ_IMAGE"
+fi

--- a/scripts/mq_seed.sh
+++ b/scripts/mq_seed.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# shellcheck source=scripts/mq_resolve_version.sh
+source scripts/mq_resolve_version.sh
+mq_resolve "${MQ_VERSION:-}"
+
 # Don't seed until both queue managers serve requests — seeding (and
 # the verify/tests that follow) must not race container startup.
 scripts/mq_wait_ready.sh

--- a/scripts/mq_start.sh
+++ b/scripts/mq_start.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# shellcheck source=scripts/mq_resolve_version.sh
+source scripts/mq_resolve_version.sh
+mq_resolve "${MQ_VERSION:-}"
+
 docker compose -f config/docker-compose.yml up -d
 
 # Block until both queue managers serve requests reliably.  The

--- a/scripts/mq_stop.sh
+++ b/scripts/mq_stop.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Resolve the selected MQ version so COMPOSE_PROJECT_NAME targets the
+# right per-version environment.
+# shellcheck source=scripts/mq_resolve_version.sh
+source scripts/mq_resolve_version.sh
+mq_resolve "${MQ_VERSION:-}"
+
 docker compose -f config/docker-compose.yml down

--- a/scripts/mq_verify.sh
+++ b/scripts/mq_verify.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# shellcheck source=scripts/mq_resolve_version.sh
+source scripts/mq_resolve_version.sh
+mq_resolve "${MQ_VERSION:-}"
+
 mq_admin_user="${MQ_ADMIN_USER:-mqadmin}"
 mq_admin_password="${MQ_ADMIN_PASSWORD:-mqadmin}"
 

--- a/scripts/mq_versions_matrix.sh
+++ b/scripts/mq_versions_matrix.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Print the manifest's version aliases as a compact JSON array, for use
+# as a GitHub Actions matrix (consumed via fromJSON).
+set -euo pipefail
+
+MQ_VERSIONS_FILE="${MQ_VERSIONS_FILE:-mq-versions.json}"
+jq -c '.versions | keys' "$MQ_VERSIONS_FILE"

--- a/tests/fixtures/mq-versions.json
+++ b/tests/fixtures/mq-versions.json
@@ -1,0 +1,7 @@
+{
+  "default": "9.4.5",
+  "versions": {
+    "9.4.5": { "image": "test/mq:9.4.5", "caps": [] },
+    "10.0": { "image": "test/mq:10.0", "caps": ["chstatus-quantum-safe"] }
+  }
+}

--- a/tests/test_lifecycle_wiring.sh
+++ b/tests/test_lifecycle_wiring.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Verifies a lifecycle script resolves the per-version Compose project
+# name and passes it to docker. Stubs `docker` on PATH to capture env.
+set -uo pipefail
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# Fake docker: record COMPOSE_PROJECT_NAME, then succeed.
+mkdir -p "$tmp/bin"
+{
+  echo '#!/usr/bin/env bash'
+  echo 'printf "%s" "${COMPOSE_PROJECT_NAME:-UNSET}" > "$CAPTURE_FILE"'
+  echo 'exit 0'
+} > "$tmp/bin/docker"
+chmod +x "$tmp/bin/docker"
+
+export CAPTURE_FILE="$tmp/project"
+PATH="$tmp/bin:$PATH" MQ_VERSION=10.0 bash scripts/mq_stop.sh >/dev/null 2>&1
+
+got="$(cat "$tmp/project" 2>/dev/null || echo MISSING)"
+if [ "$got" = "mq-dev-10_0" ]; then
+  echo "ok   - mq_stop.sh resolves per-version project name"; echo "PASS"
+else
+  echo "FAIL - expected mq-dev-10_0 got [$got]"; exit 1
+fi

--- a/tests/test_manifest.sh
+++ b/tests/test_manifest.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Validates the real mq-versions.json manifest structure.
+set -uo pipefail
+
+MANIFEST="mq-versions.json"
+fails=0
+check() { # description, condition-exit-code
+  if [ "$2" -eq 0 ]; then echo "ok   - $1"; else echo "FAIL - $1"; fails=$((fails + 1)); fi
+}
+
+jq -e . "$MANIFEST" >/dev/null 2>&1; check "manifest is valid JSON" $?
+
+jq -e '.default as $d | .versions | has($d)' "$MANIFEST" >/dev/null 2>&1
+check "default names an existing version" $?
+
+jq -e '.versions | to_entries | all(.value.image | type == "string" and length > 0)' \
+  "$MANIFEST" >/dev/null 2>&1
+check "every version has a non-empty image" $?
+
+jq -e '.versions | to_entries | all(.value.caps | type == "array")' \
+  "$MANIFEST" >/dev/null 2>&1
+check "every version has a caps array" $?
+
+[ "$fails" -eq 0 ] && echo "PASS" || { echo "$fails check(s) failed"; exit 1; }

--- a/tests/test_resolve_version.sh
+++ b/tests/test_resolve_version.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Covers scripts/mq_resolve_version.sh in both CLI and sourced modes.
+set -uo pipefail
+
+export MQ_VERSIONS_FILE="tests/fixtures/mq-versions.json"
+HELPER="scripts/mq_resolve_version.sh"
+fails=0
+eq() { # description, actual, expected
+  if [ "$2" = "$3" ]; then echo "ok   - $1"
+  else echo "FAIL - $1: expected [$3] got [$2]"; fails=$((fails + 1)); fi
+}
+ok_nonzero() { # description, exit-code
+  if [ "$2" -ne 0 ]; then echo "ok   - $1"
+  else echo "FAIL - $1: expected non-zero exit"; fails=$((fails + 1)); fi
+}
+
+# CLI mode: explicit alias prints its image.
+eq "cli resolves 10.0 image" "$(bash "$HELPER" 10.0)" "test/mq:10.0"
+
+# CLI mode: no alias uses the manifest default (9.4.5).
+eq "cli no-arg uses default image" "$(bash "$HELPER")" "test/mq:9.4.5"
+
+# CLI mode: unknown alias fails and names valid versions.
+err="$(bash "$HELPER" bogus 2>&1)"; rc=$?
+ok_nonzero "cli unknown alias exits non-zero" "$rc"
+case "$err" in
+  *"unknown MQ version"*"9.4.5"*"10.0"*) echo "ok   - error lists valid versions" ;;
+  *) echo "FAIL - error message missing valid versions: $err"; fails=$((fails + 1)) ;;
+esac
+
+# Sourced mode: exports the full signal set for 10.0.
+( set -e
+  # shellcheck disable=SC1090
+  source "$HELPER"
+  mq_resolve 10.0
+  [ "$MQ_VERSION" = "10.0" ] || { echo "FAIL - sourced MQ_VERSION"; exit 1; }
+  [ "$MQ_IMAGE" = "test/mq:10.0" ] || { echo "FAIL - sourced MQ_IMAGE"; exit 1; }
+  [ "$MQ_CAPS" = '["chstatus-quantum-safe"]' ] || { echo "FAIL - sourced MQ_CAPS [$MQ_CAPS]"; exit 1; }
+  [ "$COMPOSE_PROJECT_NAME" = "mq-dev-10_0" ] || { echo "FAIL - sourced project name [$COMPOSE_PROJECT_NAME]"; exit 1; }
+  echo "ok   - sourced mode exports version/image/caps/project"
+) || fails=$((fails + 1))
+
+# Sourced mode: 9.4.5 caps default to [].
+( set -e
+  # shellcheck disable=SC1090
+  source "$HELPER"
+  mq_resolve 9.4.5
+  [ "$MQ_CAPS" = "[]" ] || { echo "FAIL - 9.4.5 caps [$MQ_CAPS]"; exit 1; }
+  echo "ok   - 9.4.5 caps default to []"
+) || fails=$((fails + 1))
+
+[ "$fails" -eq 0 ] && echo "PASS" || { echo "$fails check(s) failed"; exit 1; }

--- a/tests/test_versions_matrix.sh
+++ b/tests/test_versions_matrix.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Covers scripts/mq_versions_matrix.sh against the fixture manifest.
+set -uo pipefail
+
+export MQ_VERSIONS_FILE="tests/fixtures/mq-versions.json"
+out="$(bash scripts/mq_versions_matrix.sh)"
+if [ "$out" = '["10.0","9.4.5"]' ]; then
+  echo "ok   - emits sorted JSON array of aliases"; echo "PASS"
+else
+  echo "FAIL - expected [\"10.0\",\"9.4.5\"] got [$out]"; exit 1
+fi


### PR DESCRIPTION
# Pull Request

## Summary

- Introduces a single mq-versions.json manifest plus a version-resolve helper, per-version Docker volume isolation, setup-mq action version/image/caps I/O, and a reusable matrix workflow, so the dev environment runs one selectable MQ version per run (9.4.5 and 10.0) on the stable contract ports and consuming repos can integration-test across versions.

## Issue Linkage

- Ref #157

## Notes

- Default stays 9.4.5; the flip to 10.0 is gated on the mapper fix in mq-rest-admin-common#217 (full attribute enumeration tracked in #219). New local prerequisite: jq. Contract invariant: ports/QM names/users unchanged across versions; consumers track the rolling vX.Y tag. Review trail: each of the 8 tasks passed spec+quality review; an opus whole-branch review flagged one Important doc gap (action Inputs/Outputs tables) which was fixed and re-reviewed RESOLVED. Tests: 13 checks across 4 plain-bash files, all pass; vrg-validate green. NOTE FOR MAINTAINER: the branch adds two workflow files (.github/workflows/mq-versions.yml, shell-tests.yml); pushing them requires elevated permissions (user identity push was rejected), so a maintainer push is needed before vrg-submit-pr. Non-blocking follow-ups: COMPOSE_PROJECT_NAME casing if a consumer passes an uppercase project-name; the single-version README example still uses @main.